### PR TITLE
[HotFix] Set restrict mode to false

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@ module.exports = {
   images: {
     domains: process.env.NEXT_PUBLIC_IMAGE_DOMAINS.split(", "),
   },
-  reactStrictMode: true,
+  reactStrictMode: false,
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
## Description

Hydration was failing with material-ui 4, reason being, it does not work in restrict mode https://github.com/vercel/next.js/issues/26799#issuecomment-876950983

Setting it to false, until we move to material-ui v5
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
