### PR TITLE
[Fix] Heading Fonts

### DIFF
--- a/src/components/DataVisuals/index.js
+++ b/src/components/DataVisuals/index.js
@@ -22,7 +22,7 @@ const DataVisuals = ({ title, items, ...props }) => {
   return (
     <Section classes={{ root: classes.root }}>
       {title && (
-        <Typography variant="h3" className={classes.title}>
+        <Typography variant="h4" className={classes.title}>
           {title}
         </Typography>
       )}

--- a/src/components/DataVisuals/useStyles.js
+++ b/src/components/DataVisuals/useStyles.js
@@ -3,8 +3,6 @@ import { makeStyles } from "@material-ui/core/styles";
 const useStyles = makeStyles(({ typography, breakpoints, palette }) => ({
   root: {},
   title: {
-    fontWeight: 900,
-    textTransform: "uppercase",
     padding: `${typography.pxToRem(40)} 0`,
     [breakpoints.only("md")]: {
       paddingTop: typography.pxToRem(80),

--- a/src/components/ExploreCard/index.js
+++ b/src/components/ExploreCard/index.js
@@ -15,7 +15,7 @@ const ExploreCard = ({ item, ...props }) => {
       image={image}
       classes={{ root: classes.root, cardMedia: classes.cardMedia }}
     >
-      <Typography className={classes.title} variant="h4">
+      <Typography className={classes.title} variant="h5">
         {title}
       </Typography>
       <Typography className={classes.description}>{description}</Typography>

--- a/src/components/ExploreCard/useStyles.js
+++ b/src/components/ExploreCard/useStyles.js
@@ -19,7 +19,6 @@ const useStyles = makeStyles(({ breakpoints, typography }) => ({
   title: {
     marginTop: typography.pxToRem(20),
     marginBottom: typography.pxToRem(20),
-    color: "#000",
   },
   description: {
     color: "#000",

--- a/src/components/ExploreOtherTools/index.js
+++ b/src/components/ExploreOtherTools/index.js
@@ -32,7 +32,7 @@ const ExploreOtherTools = ({ title, items, ...props }) => {
   return (
     <div className={classes.root}>
       <Section>
-        <Typography variant="h3" className={classes.title}>
+        <Typography variant="h4" className={classes.title}>
           {title}
         </Typography>
 

--- a/src/components/ExploreOtherTools/useStyles.js
+++ b/src/components/ExploreOtherTools/useStyles.js
@@ -7,10 +7,8 @@ const useStyles = makeStyles(({ typography, palette }) => ({
   },
   section: {},
   title: {
-    fontWeight: "bold",
     textAlign: "center",
     marginBottom: typography.pxToRem(40),
-    color: "#000",
   },
   dots: {
     margin: `0 ${typography.pxToRem(30)}`,

--- a/src/components/FeaturedStoryCard/index.js
+++ b/src/components/FeaturedStoryCard/index.js
@@ -14,10 +14,12 @@ function FeaturedStoryCard({
   href,
   image,
   title,
+  variant: variantProp,
   ...props
 }) {
   const classes = useStyles(props);
 
+  const variant = variantProp === "news" ? "h4" : "h3";
   return (
     <Grid container className={classes.root}>
       <Grid item xs={12} md={7}>
@@ -27,7 +29,7 @@ function FeaturedStoryCard({
       </Grid>
       <Grid item xs={12} md={5} className={classes.content}>
         {title && (
-          <Typography variant="h3" className={classes.title}>
+          <Typography variant={variant} className={classes.title}>
             {title}
           </Typography>
         )}
@@ -52,6 +54,7 @@ FeaturedStoryCard.propTypes = {
   image: PropTypes.string,
   href: PropTypes.string,
   ctaText: PropTypes.string,
+  variant: PropTypes.oneOf(["insights", "news"]),
 };
 FeaturedStoryCard.defaultProps = {
   description: undefined,
@@ -59,5 +62,6 @@ FeaturedStoryCard.defaultProps = {
   image: undefined,
   href: undefined,
   ctaText: undefined,
+  variant: "news",
 };
 export default FeaturedStoryCard;

--- a/src/components/FeaturedStoryCard/index.stories.js
+++ b/src/components/FeaturedStoryCard/index.stories.js
@@ -32,6 +32,12 @@ export default {
         type: "text",
       },
     },
+    variant: {
+      control: {
+        type: "select",
+      },
+      options: ["insights", "news"],
+    },
   },
 };
 
@@ -52,4 +58,5 @@ Default.args = {
   href: "/?path=/story/components-featured-story-card--default",
   ctaText: "Read More",
   image: cardImage,
+  variant: "news",
 };

--- a/src/components/FeaturedStoryCard/useStyles.js
+++ b/src/components/FeaturedStoryCard/useStyles.js
@@ -45,13 +45,7 @@ const useStyles = makeStyles(({ breakpoints, typography, widths }) => ({
       height: typography.pxToRem(415),
     },
   },
-  title: {
-    fontWeight: 400,
-    [breakpoints.up("md")]: {
-      fontWeight: 900,
-      textTransform: "uppercase",
-    },
-  },
+  title: {},
 }));
 
 export default useStyles;

--- a/src/components/HowItWorks/useStyles.js
+++ b/src/components/HowItWorks/useStyles.js
@@ -101,10 +101,7 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
     },
   },
   title: {
-    fontWeight: 900,
-    textTransform: "uppercase",
     marginTop: typography.pxToRem(18),
-    color: palette.grey.dark,
   },
   description: {
     fontFamily: typography.body1.fontFamily,

--- a/src/components/InsightCard/index.js
+++ b/src/components/InsightCard/index.js
@@ -29,7 +29,7 @@ const InsightCard = ({
       href={href}
     >
       {title && (
-        <Typography variant="h4" className={classes.cardTitle}>
+        <Typography variant="h5" className={classes.cardTitle}>
           {title}
         </Typography>
       )}

--- a/src/components/Newsletter/index.js
+++ b/src/components/Newsletter/index.js
@@ -7,11 +7,9 @@ import React from "react";
 import email from "@/pesayetu/assets/icons/Component 117 – 1@2x.png";
 import { ReactComponent as EnvelopeIcon } from "@/pesayetu/assets/icons/Group 4767.svg";
 
-const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
+const useStyles = makeStyles(({ breakpoints, typography }) => ({
   section: {},
   title: {
-    fontWeight: "900",
-    color: palette.grey.dark,
     display: "flex",
     alignItems: "center",
     marginBottom: typography.pxToRem(19.93),

--- a/src/components/Partners/Partners.js
+++ b/src/components/Partners/Partners.js
@@ -5,13 +5,11 @@ import Image from "next/image";
 import PropTypes from "prop-types";
 import React from "react";
 
-const useStyles = makeStyles(({ palette, typography }) => ({
+const useStyles = makeStyles(({ typography }) => ({
   root: {
     paddingTop: typography.pxToRem(56.69),
   },
   title: {
-    fontWeight: 900,
-    color: palette.grey.dark,
     marginBottom: typography.pxToRem(49.38),
   },
   link: {

--- a/src/components/StoriesInsights/Content.js
+++ b/src/components/StoriesInsights/Content.js
@@ -19,7 +19,7 @@ function Content({ description, title, ctaText, href, ...props }) {
       classes={{ root: classes.card, focusHighlight: classes.focusHighlight }}
     >
       {title && (
-        <Typography variant="h4" className={classes.cardTitle}>
+        <Typography variant="h5" className={classes.cardTitle}>
           {title}
         </Typography>
       )}

--- a/src/components/StoriesInsights/useStyles.js
+++ b/src/components/StoriesInsights/useStyles.js
@@ -99,7 +99,6 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
   },
   cardTitle: {
     marginBottom: typography.pxToRem(20),
-    color: "#212529",
   },
   cardDescription: {
     marginBottom: typography.pxToRem(20),

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -4,7 +4,18 @@ import { deepmerge } from "@material-ui/utils";
 import chevronrightDark from "@/pesayetu/assets/icons/Group 997-dark.svg";
 import chevronright from "@/pesayetu/assets/icons/Group 997.svg";
 
-const FONT_FAMILY_TEXT = '"Poppins", "sans-serif"';
+const FONT_FAMILY = '"Poppins", "sans-serif"';
+
+const buildVariant = (
+  fontWeight,
+  letterSpacing = 0,
+  textTransform = "none"
+) => ({
+  fontFamily: FONT_FAMILY,
+  fontWeight,
+  letterSpacing,
+  textTransform,
+});
 
 const theme = createTheme({
   breakpoints: {
@@ -40,23 +51,49 @@ const theme = createTheme({
     },
     divider: "#F0F0F0",
   },
+
+  // Font weights:
+  // see: https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping
+  // 300 	Light
+  // 400 	Normal
+  // 500 	Medium
+  // 600 	Semi Bold
+  // 700 	Bold
+  // 900 	Black
   typography: {
-    fontFamily: FONT_FAMILY_TEXT,
-    h1: {
-      fontWeight: 900,
+    fontFamily: FONT_FAMILY,
+    // e.g. Homepage, Hero
+    h1: buildVariant(900),
+    // e.g. Stories page, Featured Insight
+    h2: buildVariant(300),
+    // e.g. How it works, Our metrics
+    h3: buildVariant(600),
+    // e.g. Homepage, our Partners
+    h4: buildVariant(900, 0.4, "uppercase"),
+    // e.g. Homepage, Insights, Isiolo v Samburu Voter registration discrepancy
+    h5: buildVariant(500),
+    h6: {
+      fontFamily: FONT_FAMILY,
     },
-    h2: {},
-    h3: {},
-    h4: {},
-    h5: {},
-    hd: {},
-    body1: {},
-    body2: {},
     subtitle1: {
+      fontFamily: FONT_FAMILY,
       fontWeight: 500,
     },
-    subtitle2: {},
+    subtitle2: {
+      fontFamily: FONT_FAMILY,
+    },
+    body1: {
+      fontFamily: FONT_FAMILY,
+    },
+    body2: {
+      fontFamily: FONT_FAMILY,
+    },
+    button: buildVariant(600),
+    caption: {
+      fontFamily: FONT_FAMILY,
+    },
     overline: {
+      fontFamily: FONT_FAMILY,
       fontWeight: 700,
       textTransform: "uppercase",
     },
@@ -75,66 +112,53 @@ const { pxToRem } = typography;
 deepmerge(
   typography,
   {
+    // H0
     h1: {
+      color: palette.grey.dark,
       fontSize: pxToRem(30),
-      lineHeight: 40 / 30, // font 30 H0m
+      lineHeight: 40 / 30,
+      padding: `${pxToRem(1.5)} 0`, // 43 - 40
       [breakpoints.up("lg")]: {
         fontSize: pxToRem(48),
-        lineHeight: 58 / 48, // font 48 H0
+        lineHeight: 58 / 48,
         padding: `${pxToRem(4.5)} 0`, // 67 - 58
       },
     },
+    // H1
     h2: {
-      fontSize: pxToRem(38),
-      lineHeight: 48 / 38,
-      [breakpoints.up("lg")]: {
-        fontSize: pxToRem(48),
-        lineHeight: 58 / 48, // font 48 H1
-      },
+      color: palette.text.hint,
+      fontSize: pxToRem(50),
+      lineHeight: 66 / 50,
+      margin: `${pxToRem(2.5)} 0`, // 71 - 66
     },
+    // H2
     h3: {
-      fontSize: pxToRem(24),
-      lineHeight: 40 / 24,
-      [breakpoints.up("lg")]: {
-        fontSize: pxToRem(30),
-        lineHeight: 48 / 30, // font 30 H2
-      },
+      color: "#212529",
+      fontSize: pxToRem(30),
+      lineHeight: 48 / 30,
+      margin: `${pxToRem(-2.5)} 0`, // 91 - 96
     },
+    // H3
     h4: {
+      color: palette.grey.dark,
       fontSize: pxToRem(20),
       lineHeight: 30 / 20,
-      [breakpoints.up("lg")]: {
-        fontSize: pxToRem(20),
-        lineHeight: 30 / 20, // font 20 H4
-      },
+      margin: `${pxToRem(-1)} 0`, // 28 - 30
     },
+    // H4
     h5: {
+      color: "#212529",
+      fontSize: pxToRem(20),
+      lineHeight: 30 / 20,
+      margin: `${pxToRem(-1)} 0`, // 28 - 30
+    },
+    h6: {
       fontSize: pxToRem(18),
       lineHeight: 27 / 18,
       [breakpoints.up("lg")]: {
         fontSize: pxToRem(18),
-        lineHeight: 27 / 18, // font 18 H5
+        lineHeight: 27 / 18,
       },
-    },
-    h6: {
-      fontSize: pxToRem(16),
-      lineHeight: 30 / 16,
-      [breakpoints.up("lg")]: {
-        fontSize: pxToRem(16),
-        lineHeight: 30 / 16, // font 18 body1
-      },
-    },
-    body1: {
-      fontSize: pxToRem(16),
-      lineHeight: 25 / 16,
-      [breakpoints.up("lg")]: {
-        fontSize: pxToRem(16),
-        lineHeight: 25 / 16, // font 18 body1
-      },
-    },
-    body2: {
-      fontSize: pxToRem(14),
-      lineHeight: 24 / 14, // font body2 P2
     },
     subtitle1: {
       fontSize: pxToRem(16),
@@ -152,6 +176,23 @@ deepmerge(
         lineHeight: 18 / 14, // font 14 subtitle2
       },
     },
+    body1: {
+      fontSize: pxToRem(16),
+      lineHeight: 25 / 16,
+      [breakpoints.up("lg")]: {
+        fontSize: pxToRem(16),
+        lineHeight: 25 / 16, // font 18 body1
+      },
+    },
+    body2: {
+      fontSize: pxToRem(14),
+      lineHeight: 24 / 14, // font body2 P2
+    },
+    button: {
+      fontSize: pxToRem(16),
+      lineHeight: 24 / 16,
+      margin: `${pxToRem(-0.5)} 0`, // 23 - 24
+    },
     caption: {
       fontSize: pxToRem(12),
       lineHeight: 18 / 12,
@@ -161,8 +202,10 @@ deepmerge(
       },
     },
     overline: {
+      color: palette.text.hint,
       fontSize: pxToRem(14),
       lineHeight: 21 / 14,
+      margin: `${pxToRem(-0.5)} 0`, // 21 - 20
     },
   },
   { clone: false }
@@ -234,9 +277,6 @@ deepmerge(
         color: palette.primary.main,
         padding: 0,
         textTransform: "none",
-        fontWeight: "bold",
-        fontSize: pxToRem(16),
-        lineHeight: 23 / 16,
         "&:hover": {
           color: palette.grey.dark,
           backgroundColor: "transparent",
@@ -249,7 +289,7 @@ deepmerge(
           backgroundPosition: "center",
           backgroundRepeat: "no-repeat",
           marginLeft: pxToRem(20),
-          height: pxToRem(20), // Must equal button line-height
+          height: pxToRem(23), // Must equal button line-height
           width: pxToRem(30),
         },
         "&:hover::after": {
@@ -259,7 +299,7 @@ deepmerge(
           backgroundRepeat: "no-repeat",
           transition: "margin 0.3s ease",
           marginLeft: pxToRem(10),
-          height: pxToRem(20), // Must equal button line-height
+          height: pxToRem(23), // Must equal button line-height
           width: pxToRem(30),
         },
       },
@@ -267,4 +307,5 @@ deepmerge(
   }, // overides settings goes here
   { clone: false }
 );
+
 export default theme;


### PR DESCRIPTION
## Description

Standardize use of heading fonts `h1` - `h6` by defining them in theme rather than individual components.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/129349787-31ffc957-3715-4187-836f-16b1214c9361.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

