### PR TITLE
[Fix] ClickAwayDon'tListen

### DIFF
--- a/src/components/DataIndicators/IndicatorPanel.js
+++ b/src/components/DataIndicators/IndicatorPanel.js
@@ -1,0 +1,65 @@
+import { RichTypography } from "@commons-ui/core";
+import { ButtonBase, Slide } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import PropTypes from "prop-types";
+import React from "react";
+
+const useStyles = makeStyles(() => ({
+  root: {},
+  paper: {},
+  content: {},
+  title: {},
+  description: {},
+}));
+
+function IndicatorPanel({ currentItem, onClick, component, ...props }) {
+  const Component = component || Slide;
+  const classes = useStyles(props);
+  const { content, description, title, ...otherClasses } = classes;
+
+  return (
+    <Component {...props} classes={otherClasses}>
+      <ButtonBase
+        disableRipple
+        disableTouchRipple
+        onClick={onClick}
+        className={classes.content}
+      >
+        {currentItem?.title && (
+          <RichTypography variant="h3" className={classes.title}>
+            {currentItem.title}
+          </RichTypography>
+        )}
+        {currentItem?.description && (
+          <RichTypography className={classes.description}>
+            {currentItem.description}
+          </RichTypography>
+        )}
+      </ButtonBase>
+    </Component>
+  );
+}
+
+IndicatorPanel.propTypes = {
+  classes: PropTypes.shape({
+    root: PropTypes.string,
+    content: PropTypes.string,
+    title: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  component: PropTypes.elementType,
+  currentItem: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  onClick: PropTypes.func,
+};
+
+IndicatorPanel.defaultProps = {
+  classes: undefined,
+  currentItem: undefined,
+  component: undefined,
+  onClick: undefined,
+};
+
+export default IndicatorPanel;

--- a/src/components/DataIndicators/index.js
+++ b/src/components/DataIndicators/index.js
@@ -1,9 +1,6 @@
-import { RichTypography } from "@commons-ui/core";
 import {
-  ButtonBase,
   ClickAwayListener,
   Grid,
-  Typography,
   Dialog,
   Slide,
   useMediaQuery,
@@ -15,6 +12,7 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import Icon from "./Icon";
+import IndicatorPanel from "./IndicatorPanel";
 import useStyles from "./useStyles";
 
 import bg from "@/pesayetu/assets/images/Mask Group 8.png";
@@ -35,20 +33,48 @@ function DataIndicators({ items, title, ...props }) {
   if (!items?.length) {
     return null;
   }
-
   const handleIconClick = (index) => {
     setCurrentItemIndex(index);
     setChecked(true);
   };
-
-  const resetItemClick = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const resetItemClick = () => {
     setChecked(false);
     setCurrentItemIndex(null);
   };
-
   const currentItem = items[currentItemIndex];
+  const panelProps = isDesktop
+    ? {
+        in: checked,
+        mountOnEnter: true,
+        unmountOnExit: true,
+        component: Slide,
+        direction: "left",
+        timeout: 300,
+        classes: {
+          root: classes.slide,
+          content: classes.content,
+          title: classes.title,
+          description: classes.description,
+        },
+      }
+    : {
+        open: checked,
+        onClose: resetItemClick,
+        component: Dialog,
+        BackdropProps: {
+          classes: {
+            root: classes.backdrop,
+          },
+        },
+        TransitionComponent: Transition,
+        classes: {
+          root: classes.dialog,
+          paper: classes.dialogPaper,
+          content: classes.content,
+          title: classes.title,
+          description: classes.description,
+        },
+      };
 
   return (
     <div className={classes.root}>
@@ -84,72 +110,11 @@ function DataIndicators({ items, title, ...props }) {
             </Grid>
           </ClickAwayListener>
         </div>
-        {isDesktop ? (
-          <Slide
-            in={checked}
-            mountOnEnter
-            unmountOnExit
-            className={classes.slide}
-            direction="left"
-            timeout={300}
-          >
-            <ButtonBase
-              disableRipple
-              disableTouchRipple
-              onClick={resetItemClick}
-              className={classes.content}
-            >
-              {currentItem?.title && (
-                <Typography
-                  component="div"
-                  variant="h3"
-                  className={classes.title}
-                >
-                  {currentItem.title}
-                </Typography>
-              )}
-              {currentItem?.description && (
-                <RichTypography component="div" className={classes.description}>
-                  {currentItem.description}
-                </RichTypography>
-              )}
-            </ButtonBase>
-          </Slide>
-        ) : (
-          <Dialog
-            open={checked}
-            onClose={resetItemClick}
-            BackdropProps={{
-              classes: {
-                root: classes.backdrop,
-              },
-            }}
-            TransitionComponent={Transition}
-            classes={{ root: classes.dialog, paper: classes.dialogPaper }}
-          >
-            <ButtonBase
-              disableRipple
-              disableTouchRipple
-              onClick={resetItemClick}
-              className={classes.content}
-            >
-              {currentItem?.title && (
-                <Typography
-                  component="div"
-                  variant="h3"
-                  className={classes.title}
-                >
-                  {currentItem.title}
-                </Typography>
-              )}
-              {currentItem?.description && (
-                <RichTypography component="div" className={classes.description}>
-                  {currentItem.description}
-                </RichTypography>
-              )}
-            </ButtonBase>
-          </Dialog>
-        )}
+        <IndicatorPanel
+          {...panelProps}
+          onClick={resetItemClick}
+          currentItem={currentItem}
+        />
       </div>
     </div>
   );

--- a/src/components/DataIndicators/useStyles.js
+++ b/src/components/DataIndicators/useStyles.js
@@ -11,6 +11,10 @@ const useStyles = makeStyles(({ typography, breakpoints, palette }) => ({
   },
   section: {
     display: "flex",
+    overflow: "hidden",
+    [breakpoints.up("lg")]: {
+      position: "relative",
+    },
   },
   background: {
     position: "absolute",
@@ -20,7 +24,7 @@ const useStyles = makeStyles(({ typography, breakpoints, palette }) => ({
   indicatorsContainer: {
     width: "100%",
     height: typography.pxToRem(672),
-    transition: "width 0.3s ease-in-out",
+    transition: "width 0.3s ease-out",
     [breakpoints.up("lg")]: {
       height: typography.pxToRem(600),
     },
@@ -49,6 +53,7 @@ const useStyles = makeStyles(({ typography, breakpoints, palette }) => ({
     marginBottom: typography.pxToRem(16),
     display: "flex",
     justifyContent: "center",
+    transition: "margin-right 0.3s ease-out",
     [breakpoints.up("lg")]: {
       display: "initial",
       width: "auto",
@@ -73,6 +78,9 @@ const useStyles = makeStyles(({ typography, breakpoints, palette }) => ({
     },
   },
   slide: {
+    position: "absolute",
+    right: 0,
+    top: 0,
     backgroundColor: palette.primary.main,
     display: "flex",
     justifyContent: "flex-start",
@@ -127,11 +135,6 @@ const useStyles = makeStyles(({ typography, breakpoints, palette }) => ({
     [breakpoints.up("md")]: {
       width: typography.pxToRem(355),
       padding: `${typography.pxToRem(50)} ${typography.pxToRem(36)}`,
-    },
-    [breakpoints.up("lg")]: {
-      width: typography.pxToRem(480),
-      height: typography.pxToRem(600),
-      padding: `${typography.pxToRem(76)} ${typography.pxToRem(84)}`,
     },
   },
   content: {


### PR DESCRIPTION
## Description

The current ClickAwayListener on DataIndicators swallows all click events and hence navigation menu button, etc., are not clickable on mobile screens. This PR addresses that.

The PR also improves transitions on desktop screen to be, you know, silky smooth.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### PR

![Peek 2021-09-07 18-17](https://user-images.githubusercontent.com/1779590/132372275-bee3a0a8-f759-4b0d-94cf-1cd63ef6b3b2.gif)

### Current

![Peek 2021-09-07 18-18](https://user-images.githubusercontent.com/1779590/132372294-d7dfc2a5-67a7-4dc5-9e81-19968eb5ab58.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

