### PR TITLE
[HotFix] Optimize font loading

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -9,6 +9,14 @@ export default class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
+          {/* Used in page headers */}
+          <link
+            rel="preload"
+            href="/fonts/poppins-v15-latin-900.woff2"
+            as="font"
+            type="font/woff2"
+            crossOrigin=""
+          />
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
         </Head>

--- a/src/theme/fonts.css
+++ b/src/theme/fonts.css
@@ -3,8 +3,9 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url("/fonts/poppins-v15-latin-300.eot"); /* IE9 Compat Modes */
-  src: local(""),
+  src: local("Poppins Light"),
     url("/fonts/poppins-v15-latin-300.eot?#iefix") format("embedded-opentype"),
     /* IE6-IE8 */ url("/fonts/poppins-v15-latin-300.woff2") format("woff2"),
     /* Super Modern Browsers */ url("/fonts/poppins-v15-latin-300.woff")
@@ -20,8 +21,9 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url("/fonts/poppins-v15-latin-regular.eot"); /* IE9 Compat Modes */
-  src: local(""),
+  src: local("Poppins Regular"),
     url("/fonts/poppins-v15-latin-regular.eot?#iefix")
       format("embedded-opentype"),
     /* IE6-IE8 */ url("/fonts/poppins-v15-latin-regular.woff2") format("woff2"),
@@ -38,8 +40,9 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: url("/fonts/poppins-v15-latin-500.eot"); /* IE9 Compat Modes */
-  src: local(""),
+  src: local("Poppins Medium"),
     url("/fonts/poppins-v15-latin-500.eot?#iefix") format("embedded-opentype"),
     /* IE6-IE8 */ url("/fonts/poppins-v15-latin-500.woff2") format("woff2"),
     /* Super Modern Browsers */ url("/fonts/poppins-v15-latin-500.woff")
@@ -55,8 +58,9 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: url("/fonts/poppins-v15-latin-600.eot"); /* IE9 Compat Modes */
-  src: local(""),
+  src: local("Poppins SemiBold"),
     url("/fonts/poppins-v15-latin-600.eot?#iefix") format("embedded-opentype"),
     /* IE6-IE8 */ url("/fonts/poppins-v15-latin-600.woff2") format("woff2"),
     /* Super Modern Browsers */ url("/fonts/poppins-v15-latin-600.woff")
@@ -72,8 +76,9 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url("/fonts/poppins-v15-latin-700.eot"); /* IE9 Compat Modes */
-  src: local(""),
+  src: local("Poppins Bold"),
     url("/fonts/poppins-v15-latin-700.eot?#iefix") format("embedded-opentype"),
     /* IE6-IE8 */ url("/fonts/poppins-v15-latin-700.woff2") format("woff2"),
     /* Super Modern Browsers */ url("/fonts/poppins-v15-latin-700.woff")
@@ -89,8 +94,9 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 900;
+  font-display: swap;
   src: url("/fonts/poppins-v15-latin-900.eot"); /* IE9 Compat Modes */
-  src: local(""),
+  src: local("Poppins Black"),
     url("/fonts/poppins-v15-latin-900.eot?#iefix") format("embedded-opentype"),
     /* IE6-IE8 */ url("/fonts/poppins-v15-latin-900.woff2") format("woff2"),
     /* Super Modern Browsers */ url("/fonts/poppins-v15-latin-900.woff")


### PR DESCRIPTION
## Description

 - [x] Enable `font-display: swap`,
 - [x] Use locally installed versions if found,
 - [x] Preload Black font used on page headers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

