### PR TITLE
[Feature] openAFRICA Datasets

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,3 +33,7 @@ NEXT_PUBLIC_IMAGE_DOMAINS="cms.dev.codeforafrica.org"
 
 # HURUmap URL
 HURUMAP_API_URL="https://ng.hurumap.org/api/v1/"
+
+# openAFRICA domains
+# A comma-separated list of domains to openAFRICA (or any CKAN-based site domain)
+NEXT_PUBLIC_OPENAFRICA_DOMAINS=

--- a/src/components/Sources/CarouselItem.js
+++ b/src/components/Sources/CarouselItem.js
@@ -37,11 +37,11 @@ function CarouselItem({ items, type, ...props }) {
               variant="body1"
               className={clsx(classes.text, classes.description)}
             >
-              {item.description}
+              {isDatasets ? item.date : item.description}
             </Typography>
           </Grid>
           <Grid item xs={12} lg={5} className={classes.linkContent}>
-            {isDatasets && item.types?.length > 0 ? (
+            {isDatasets ? (
               <Grid
                 item
                 xs={12}
@@ -51,11 +51,17 @@ function CarouselItem({ items, type, ...props }) {
                 alignItems="center"
                 className={classes.dataTypes}
               >
-                {item.types.map((data) => (
-                  <Typography className={classes.typeContent} key={data.name}>
-                    {data.name}
+                {item?.types?.map(({ href, name }) => (
+                  <Typography
+                    component={href ? Link : undefined}
+                    href={href || undefined}
+                    underline={href ? "none" : undefined}
+                    className={classes.typeContent}
+                    key={name}
+                  >
+                    {name}
                   </Typography>
-                ))}
+                )) ?? null}
               </Grid>
             ) : null}
             <Link

--- a/src/config.js
+++ b/src/config.js
@@ -427,77 +427,77 @@ export const datasetsArgs = {
   items: [
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },

--- a/src/pages/data/[[...slug]].js
+++ b/src/pages/data/[[...slug]].js
@@ -7,6 +7,7 @@ import Hero from "@/pesayetu/components/OtherHero";
 import Page from "@/pesayetu/components/Page";
 import formatBlocksForSections from "@/pesayetu/functions/formatBlocksForSections";
 import getPostTypeStaticProps from "@/pesayetu/functions/postTypes/getPostTypeStaticProps";
+import fetchOpenAfricaDatasets from "@/pesayetu/utils/fetchOpenAfricaDatasets";
 
 const types = ["documents", "datasets"];
 
@@ -62,6 +63,22 @@ export async function getStaticProps({ params, preview, previewData }) {
   }
 
   const blocks = formatBlocksForSections(props?.post?.blocks);
+  blocks.documentAndDatasets =
+    (await Promise.all(
+      blocks?.documentAndDatasets?.map(
+        async ({ type, items: originalItems, ...others }) => {
+          let items = originalItems;
+          if (type === "datasets") {
+            // A single url can contain multiple datasets & hence the need
+            // for flat(1)
+            items = (
+              await Promise.all(items.map(fetchOpenAfricaDatasets))
+            ).flat(1);
+          }
+          return { ...others, type, items };
+        }
+      )
+    )) || null;
   return {
     props: {
       ...props,

--- a/src/utils/fetchOpenAfricaDatasets.js
+++ b/src/utils/fetchOpenAfricaDatasets.js
@@ -1,0 +1,66 @@
+import fetchJson from "./fetchJson";
+
+const DATASET_API_PATH = "/api/3/action/package_show?id=";
+const GROUP_API_PATH = "/api/3/action/package_search?fq=groups:";
+
+async function extractDatasets(origin, results) {
+  return results.map((result) => {
+    const {
+      metadata_modified: updatedAt,
+      name,
+      notes: description,
+      title,
+    } = result;
+    const types = result.resources?.map(({ format, url }) => ({
+      href: url,
+      name: format,
+    }));
+    return {
+      date: `Updated: ${new Date(updatedAt).toISOString().substr(0, 10)}`,
+      description,
+      href: `${origin}/dataset/${name}`,
+      title,
+      type: "dataset",
+      types,
+    };
+  });
+}
+
+async function fetchOpenAfricaDatasets(source) {
+  const { href } = source;
+  try {
+    const url = new URL(href);
+    if (
+      process.env.NEXT_PUBLIC_OPENAFRICA_DOMAINS.split(",")
+        .map((d) => d.trim())
+        .includes(url.hostname)
+    ) {
+      const { pathname } = url;
+      let apiPath;
+      if (pathname.startsWith("/dataset/")) {
+        const id = pathname.replace("/dataset/", "").split("/")[0];
+        if (id) {
+          apiPath = `${DATASET_API_PATH}${id}`;
+        }
+      } else if (pathname.startsWith("/group/")) {
+        const groups = pathname.replace("/group/", "").split("/")[0];
+        if (groups) {
+          apiPath = `${GROUP_API_PATH}${groups}`;
+        }
+      }
+      if (apiPath) {
+        const json = await fetchJson(`${url.origin}${apiPath}`);
+        // group datasets are in result.results while individual dataset
+        // is in result
+        const results = json.result.results || [json.result];
+        return extractDatasets(url.origin, results);
+      }
+    }
+  } catch (e) {
+    /* We'll return original source */
+  }
+
+  return source;
+}
+
+export default fetchOpenAfricaDatasets;


### PR DESCRIPTION
## Description

This PR adds ability to fetch datasets information from openAFRICA (and any other CKAN instance) based on url received from the CMS. CKAN's [Action API](https://docs.ckan.org/en/2.9/api/) is used.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![localhost_3000_data_datasets](https://user-images.githubusercontent.com/1779590/134195770-44ece52a-a8ab-4a70-adf3-0c0d0a19bb06.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

