### PR TITLE
[Feature] AFRICA

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,3 +33,7 @@ NEXT_PUBLIC_IMAGE_DOMAINS="cms.dev.codeforafrica.org"
 
 # HURUmap URL
 HURUMAP_API_URL="https://ng.hurumap.org/api/v1/"
+
+# openAFRICA domains
+# A comma-separated list of domains to openAFRICA (or any CKAN-based site domain)
+NEXT_PUBLIC_OPENAFRICA_DOMAINS=

--- a/.env.sample
+++ b/.env.sample
@@ -37,3 +37,8 @@ HURUMAP_API_URL="https://ng.hurumap.org/api/v1/"
 # openAFRICA domains
 # A comma-separated list of domains to openAFRICA (or any CKAN-based site domain)
 NEXT_PUBLIC_OPENAFRICA_DOMAINS=
+
+# sourceAFRICA domains
+# A comma-separated list of domains to sourceAFRICA (or any DocumentCloud
+# based site domain)
+NEXT_PUBLIC_SOURCEAFRICA_DOMAINS=

--- a/src/components/DatasetsAndDocuments/index.stories.js
+++ b/src/components/DatasetsAndDocuments/index.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import DatasetsAndDocuments from ".";
 
-import { datasetsAndDocumentsArgs } from "@/pesayetu/config";
+import { documentsAndDatasetsArgs } from "@/pesayetu/config";
 
 export default {
   title: "Sections/DatasetsAndDocuments",
@@ -21,6 +21,6 @@ const Template = (args) => <DatasetsAndDocuments {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  ...datasetsAndDocumentsArgs,
+  ...documentsAndDatasetsArgs,
   activeType: "documents",
 };

--- a/src/components/DatasetsAndDocuments/useStyles.js
+++ b/src/components/DatasetsAndDocuments/useStyles.js
@@ -30,12 +30,13 @@ const useStyles = makeStyles(({ breakpoints, typography }) => ({
     color: "#707070",
     fontSize: typography.pxToRem(11),
     padding: 0,
+    marginLeft: 0,
   },
   text: {
     padding: 0,
   },
   textContent: {
-    flexDirection: "column ",
+    flexDirection: "column",
   },
   linkContent: {
     flexDirection: "column",

--- a/src/components/Sources/CarouselItem.js
+++ b/src/components/Sources/CarouselItem.js
@@ -37,11 +37,11 @@ function CarouselItem({ items, type, ...props }) {
               variant="body1"
               className={clsx(classes.text, classes.description)}
             >
-              {item.description}
+              {isDatasets ? item.date : item.description}
             </Typography>
           </Grid>
           <Grid item xs={12} lg={5} className={classes.linkContent}>
-            {isDatasets && item.types?.length > 0 ? (
+            {isDatasets ? (
               <Grid
                 item
                 xs={12}
@@ -51,11 +51,17 @@ function CarouselItem({ items, type, ...props }) {
                 alignItems="center"
                 className={classes.dataTypes}
               >
-                {item.types.map((data) => (
-                  <Typography className={classes.typeContent} key={data.name}>
-                    {data.name}
+                {item?.types?.map(({ href, name }) => (
+                  <Typography
+                    component={href ? Link : undefined}
+                    href={href || undefined}
+                    underline={href ? "none" : undefined}
+                    className={classes.typeContent}
+                    key={name}
+                  >
+                    {name}
                   </Typography>
-                ))}
+                )) ?? null}
               </Grid>
             ) : null}
             <Link

--- a/src/components/Sources/CarouselItem.js
+++ b/src/components/Sources/CarouselItem.js
@@ -18,29 +18,39 @@ const useStyles = makeStyles(() => ({
   link: {},
 }));
 
-function CarouselItem({ items, type, ...props }) {
+function CarouselItem({ ctaText, items, type, ...props }) {
   const classes = useStyles(props);
   const isDatasets = type === "datasets";
 
   return (
     <div className={classes.root}>
       {items.map((item) => (
-        <Grid container className={classes.sources} key={item.title}>
-          <Grid item xs={12} lg={7} className={classes.textContent}>
+        <Grid key={item.title} container className={classes.sources}>
+          <Grid
+            item
+            xs={12}
+            lg={isDatasets ? 7 : 10}
+            className={classes.textContent}
+          >
             <Typography
               variant="body1"
               className={clsx(classes.text, classes.title)}
             >
-              {item.title}
+              {isDatasets ? item.title : item.date}
             </Typography>
             <Typography
               variant="body1"
               className={clsx(classes.text, classes.description)}
             >
-              {isDatasets ? item.date : item.description}
+              {isDatasets ? item.date : item.title}
             </Typography>
           </Grid>
-          <Grid item xs={12} lg={5} className={classes.linkContent}>
+          <Grid
+            item
+            xs={12}
+            lg={isDatasets ? 5 : 2}
+            className={classes.linkContent}
+          >
             {isDatasets ? (
               <Grid
                 item
@@ -70,7 +80,7 @@ function CarouselItem({ items, type, ...props }) {
               underline="always"
               variant="body2"
             >
-              Read More
+              {ctaText}
             </Link>
           </Grid>
         </Grid>
@@ -80,6 +90,7 @@ function CarouselItem({ items, type, ...props }) {
 }
 
 CarouselItem.propTypes = {
+  ctaText: PropTypes.string,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,
@@ -92,6 +103,7 @@ CarouselItem.propTypes = {
 };
 
 CarouselItem.defaultProps = {
+  ctaText: "Read More",
   items: undefined,
   type: undefined,
 };

--- a/src/components/Sources/index.js
+++ b/src/components/Sources/index.js
@@ -2,7 +2,7 @@ import { Hidden, useMediaQuery } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
 import { chunk } from "lodash";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import CarouselItem from "./CarouselItem";
 import useStyles from "./useStyles";
@@ -19,25 +19,57 @@ const responsive = {
   },
 };
 
-function Sources({ filterProps, items, type, ...props }) {
+function Sources({ ctaText, filterProps, items, type, ...props }) {
   const classes = useStyles({ ...props, type });
+  const { paginationOptions } = filterProps;
+  const [sortOrder, setSortOrder] = useState();
+  const [sortedItems, setSortedItems] = useState(items);
+  const [pageSize, setPageSize] = useState(
+    paginationOptions && paginationOptions[0]
+  );
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.up("md"));
-  const itemsToShow = isTablet ? 6 : 5;
+  const itemsToShow = isTablet ? pageSize : 5;
+  const handleSort = (e) => {
+    setSortOrder(e.target.value);
+  };
+  useEffect(() => {
+    // Array.sort happens "in place" so we need to copy the array for useState
+    // to notice the change
+    // see: https://github.com/facebook/react/issues/19780#issuecomment-688068412
+    if (sortOrder) {
+      if (sortOrder?.toLowerCase() === "least recently updated") {
+        setSortedItems([...items.sort((a, b) => a.date.localeCompare(b.date))]);
+      } else if (sortOrder?.toLowerCase() === "most recently updated") {
+        setSortedItems([...items.sort((a, b) => b.date.localeCompare(a.date))]);
+      }
+    }
+  }, [items, sortOrder]);
 
-  if (!items?.length) {
+  if (!sortedItems?.length) {
     return null;
   }
-  const carouselItems = chunk(items, itemsToShow);
+  const carouselItems = chunk(sortedItems, itemsToShow);
   return (
     <div classesName={classes.root}>
       <Hidden smDown implementation="css">
-        <SourcesFilter {...filterProps} />
+        <SourcesFilter
+          {...filterProps}
+          onPageSize={setPageSize}
+          onSort={handleSort}
+          pageSize={pageSize}
+          sortOrder={sortOrder}
+        />
       </Hidden>
-      <Carousel responsive={responsive} classes={{ dotList: classes.dotList }}>
+      <Carousel
+        responsive={responsive}
+        showDots={sortedItems.length > itemsToShow}
+        classes={{ dotList: classes.dotList }}
+      >
         {carouselItems.map((ci) => (
           <CarouselItem
             key={ci[0].title}
+            ctaText={ctaText}
             items={ci}
             type={type}
             classes={{
@@ -59,7 +91,10 @@ function Sources({ filterProps, items, type, ...props }) {
 }
 
 Sources.propTypes = {
-  filterProps: PropTypes.shape({}),
+  ctaText: PropTypes.string,
+  filterProps: PropTypes.shape({
+    paginationOptions: PropTypes.arrayOf(PropTypes.number),
+  }),
   items: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,
@@ -72,8 +107,9 @@ Sources.propTypes = {
 };
 
 Sources.defaultProps = {
-  items: undefined,
+  ctaText: undefined,
   filterProps: undefined,
+  items: undefined,
   type: undefined,
 };
 

--- a/src/components/Sources/useStyles.js
+++ b/src/components/Sources/useStyles.js
@@ -37,17 +37,16 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
     marginTop: type === "datasets" ? `-${typography.pxToRem(20)}` : undefined,
     marginBottom: type === "datasets" ? 0 : undefined,
     [breakpoints.up("lg")]: {
-      marginTop: 0,
       marginBottom: "revert",
+      marginLeft: typography.pxToRem(64),
+      marginTop: 0,
     },
   }),
   textContent: {
     display: "flex",
     flexDirection: "column",
-
     [breakpoints.up("lg")]: {
       flexDirection: "row",
-      justifyContent: "space-between",
     },
   },
   linkContent: {

--- a/src/components/SourcesFilter/index.js
+++ b/src/components/SourcesFilter/index.js
@@ -2,7 +2,7 @@ import { Grid, Typography, ButtonGroup, Button } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import clsx from "clsx";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React from "react";
 
 import Input from "./input";
 
@@ -41,16 +41,22 @@ const useStyles = makeStyles(({ typography, palette }) => ({
 const SourcesFilter = ({
   countLabel,
   count,
-  paginationLabel,
-  paginationOptions,
+  onPageSize,
+  onSort,
   orderLabel,
   orderOptions,
+  pageSize,
+  paginationLabel,
+  paginationOptions,
+  sortOrder,
   ...props
 }) => {
   const classes = useStyles(props);
-  const [selectedPageCount, setSelectedPageCount] = useState(
-    paginationOptions && paginationOptions[0]
-  );
+  const handleClick = (option) => {
+    if (onPageSize) {
+      onPageSize(option);
+    }
+  };
 
   return (
     <Grid
@@ -87,11 +93,11 @@ const SourcesFilter = ({
           {paginationOptions?.map((option) => (
             <Button
               className={clsx(classes.button, {
-                [classes.selectedOption]: option === selectedPageCount,
+                [classes.selectedOption]: option === pageSize,
               })}
-              onClick={() => setSelectedPageCount(option)}
+              onClick={() => handleClick(option)}
               key={option}
-              disabled={selectedPageCount === option}
+              disabled={option === pageSize}
             >
               <Typography variant="body2" className={classes.label}>
                 {option}
@@ -112,7 +118,7 @@ const SourcesFilter = ({
         <Typography className={classes.orderLabel} variant="body2">
           {orderLabel}
         </Typography>
-        <Input options={orderOptions} />
+        <Input onChange={onSort} options={orderOptions} selected={sortOrder} />
       </Grid>
     </Grid>
   );
@@ -121,19 +127,27 @@ const SourcesFilter = ({
 SourcesFilter.propTypes = {
   countLabel: PropTypes.string,
   count: PropTypes.number,
+  onPageSize: PropTypes.func,
+  onSort: PropTypes.func,
   orderLabel: PropTypes.string,
   orderOptions: PropTypes.arrayOf(PropTypes.shape({})),
+  pageSize: PropTypes.number,
   paginationOptions: PropTypes.PropTypes.arrayOf(PropTypes.number),
   paginationLabel: PropTypes.string,
+  sortOrder: PropTypes.string,
 };
 
 SourcesFilter.defaultProps = {
   countLabel: undefined,
   count: undefined,
+  onPageSize: undefined,
+  onSort: undefined,
   orderLabel: undefined,
   orderOptions: undefined,
+  pageSize: undefined,
   paginationOptions: undefined,
   paginationLabel: undefined,
+  sortOrder: undefined,
 };
 
 export default SourcesFilter;

--- a/src/components/SourcesFilter/input.js
+++ b/src/components/SourcesFilter/input.js
@@ -55,7 +55,6 @@ const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
 
 function Input({ label, options, selected, onChange, ...props }) {
   const classes = useStyles(props);
-
   const handleChange = (event) => {
     if (onChange) {
       onChange(event);

--- a/src/config.js
+++ b/src/config.js
@@ -427,77 +427,77 @@ export const datasetsArgs = {
   items: [
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 20/04/2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
           name: "csv",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "xls",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
         {
           name: "json",
-          link: "https://courses.academy.africa/courses/data-visualization/",
+          href: "https://courses.academy.africa/courses/data-visualization/",
         },
       ],
     },

--- a/src/config.js
+++ b/src/config.js
@@ -369,65 +369,63 @@ export const exploreTools = {
 };
 
 export const documentsArgs = {
-  type: "documents",
   filterProps: {
-    countLabel: "Documents",
+    countLabel: "Count",
     count: 65,
     orderLabel: "Order By",
-    orderOptions: ["Relevance", "Date", "Municipal"],
+    orderOptions: ["Most recently updated", "Least recently updated"],
     paginationOptions: [10, 25, 50],
     paginationLabel: "Show",
   },
   items: [
     {
-      title: "2021",
-      description: "The County Integrated Development Plan (CIDP) in Kenya",
+      date: "2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
+      title: "The County Integrated Development Plan (CIDP) in Kenya",
     },
     {
-      title: "2021",
-      description: "The County Integrated Development Plan (CIDP) in Kenya",
+      date: "2021",
       href: "https://courses.academy.africa/courses/data-visualization/",
+      title: "The County Integrated Development Plan (CIDP) in Kenya",
     },
     {
-      title: "2021",
-      description: "The County Integrated Development Plan (CIDP) in Kenya",
+      date: "2019",
       href: "https://courses.academy.africa/courses/data-visualization/",
+      title: "The County Integrated Development Plan (CIDP) in Kenya",
     },
     {
-      title: "2021",
-      description: "The County Integrated Development Plan (CIDP) in Kenya",
+      date: "2020",
       href: "https://courses.academy.africa/courses/data-visualization/",
+      title: "The County Integrated Development Plan (CIDP) in Kenya",
     },
     {
-      title: "2021",
-      description: "The County Integrated Development Plan (CIDP) in Kenya",
-      ctaText: "Read More",
+      date: "2017",
       href: "https://courses.academy.africa/courses/data-visualization/",
+      title: "The County Integrated Development Plan (CIDP) in Kenya",
     },
     {
-      title: "2021",
-      description: "The County Integrated Development Plan (CIDP) in Kenya",
-      ctaText: "Read More",
+      date: "2018",
       href: "https://courses.academy.africa/courses/data-visualization/",
+      title: "The County Integrated Development Plan (CIDP) in Kenya",
     },
   ],
+  type: "documents",
 };
 
 export const datasetsArgs = {
-  type: "datasets",
+  ctaText: "View",
   filterProps: {
-    countLabel: "Datasets",
+    countLabel: "Count",
     count: 65,
     orderLabel: "Order By",
-    orderOptions: ["Relevance", "Date"],
+    orderOptions: ["Most recently updated", "Least recently updated"],
     paginationOptions: [10, 25, 50],
     paginationLabel: "Show",
   },
   items: [
     {
       title: "Health facilities in Africa",
-      date: "Updated: 20/04/2020",
+      date: "Updated: 2020-04-20",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
@@ -446,7 +444,7 @@ export const datasetsArgs = {
     },
     {
       title: "Health facilities in Africa",
-      date: "Updated: 20/04/2020",
+      date: "Updated: 2020-04-16",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
@@ -465,7 +463,7 @@ export const datasetsArgs = {
     },
     {
       title: "Health facilities in Africa",
-      date: "Updated: 20/04/2020",
+      date: "Updated: 2020-04-17",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
@@ -484,7 +482,7 @@ export const datasetsArgs = {
     },
     {
       title: "Health facilities in Africa",
-      date: "Updated: 20/04/2020",
+      date: "Updated: 2020-04-19",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
@@ -503,7 +501,7 @@ export const datasetsArgs = {
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 2020-04-18",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
@@ -522,7 +520,7 @@ export const datasetsArgs = {
     },
     {
       title: "Health facilities in Africa",
-      description: "Updated: 20/04/2020",
+      date: "Updated: 2020-04-13",
       href: "https://courses.academy.africa/courses/data-visualization/",
       types: [
         {
@@ -540,6 +538,7 @@ export const datasetsArgs = {
       ],
     },
   ],
+  type: "datasets",
 };
 
 export const dataVisuals = {
@@ -643,7 +642,7 @@ export const footerArgs = {
   aboutVariant: "subtitle1",
 };
 
-export const datasetsAndDocumentsArgs = {
+export const documentsAndDatasetsArgs = {
   items: [
     { label: "DOCUMENTS & SPEECHES", ...documentsArgs },
     { label: "DATASETS", ...datasetsArgs },

--- a/src/functions/formatBlocksForSections.js
+++ b/src/functions/formatBlocksForSections.js
@@ -142,11 +142,11 @@ function formatFeaturedStories(attributes) {
 }
 function formatTypes(typesString) {
   return typesString.split("\n").map((item) => {
-    const [name = null, link = null] = item.split(",");
-    return { name, link };
+    const [name = null, href = null] = item.split(",").map((i) => i.trim());
+    return { name, href };
   });
 }
-function formatDocumentAndDataSet(
+function formatDocumentsAndDataSets(
   {
     countLabel,
     count,
@@ -171,7 +171,11 @@ function formatDocumentAndDataSet(
       count,
       orderLabel,
       paginationOptions: paginationOptions?.split(",").map(Number) || [],
-      orderOptions: orderOptions?.split(",") || [],
+      orderOptions:
+        orderOptions
+          ?.split(",")
+          .map((o) => o.trim())
+          .filter((o) => o) || [],
       paginationLabel,
     };
     return { items, filterProps, ...attributes, ...rest };
@@ -214,8 +218,8 @@ function format(block) {
       return formatDataIndicators(attributes);
     case "lazyblock/tutorial":
       return formatLazyBlockIteratorContentWithImage(attributes, "image");
-    case "lazyblock/document-and-datasets":
-      return formatDocumentAndDataSet(attributes, innerBlocks);
+    case "lazyblock/documents-and-datasets":
+      return formatDocumentsAndDataSets(attributes, innerBlocks);
     case "lazyblock/hero":
     case "lazyblock/about-hero":
     case "lazyblock/how-it-works":

--- a/src/pages/data/[[...slug]].js
+++ b/src/pages/data/[[...slug]].js
@@ -7,6 +7,7 @@ import Hero from "@/pesayetu/components/OtherHero";
 import Page from "@/pesayetu/components/Page";
 import formatBlocksForSections from "@/pesayetu/functions/formatBlocksForSections";
 import getPostTypeStaticProps from "@/pesayetu/functions/postTypes/getPostTypeStaticProps";
+import fetchOpenAfricaDatasets from "@/pesayetu/utils/fetchOpenAfricaDatasets";
 
 const types = ["documents", "datasets"];
 
@@ -62,6 +63,22 @@ export async function getStaticProps({ params, preview, previewData }) {
   }
 
   const blocks = formatBlocksForSections(props?.post?.blocks);
+  blocks.documentAndDatasets =
+    (await Promise.all(
+      blocks?.documentAndDatasets?.map(
+        async ({ type, items: originalItems, ...others }) => {
+          let items = originalItems;
+          if (type === "datasets") {
+            // A single url can contain multiple datasets & hence the need
+            // for flat(1)
+            items = (
+              await Promise.all(items.map(fetchOpenAfricaDatasets))
+            ).flat(1);
+          }
+          return { ...others, type, items };
+        }
+      )
+    )) || null;
   return {
     props: {
       ...props,

--- a/src/utils/fetchOpenAfricaDatasets.js
+++ b/src/utils/fetchOpenAfricaDatasets.js
@@ -3,6 +3,14 @@ import fetchJson from "./fetchJson";
 const DATASET_API_PATH = "/api/3/action/package_show?id=";
 const GROUP_API_PATH = "/api/3/action/package_search?fq=groups:";
 
+function formatDate(date) {
+  try {
+    return `Updated: ${new Date(date).toISOString().substr(0, 10)}`;
+  } catch (e) {
+    return date || null;
+  }
+}
+
 async function extractDatasets(origin, results) {
   return results.map((result) => {
     const {
@@ -16,7 +24,7 @@ async function extractDatasets(origin, results) {
       name: format,
     }));
     return {
-      date: `Updated: ${new Date(updatedAt).toISOString().substr(0, 10)}`,
+      date: formatDate(updatedAt),
       description,
       href: `${origin}/dataset/${name}`,
       title,
@@ -60,7 +68,8 @@ async function fetchOpenAfricaDatasets(source) {
     /* We'll return original source */
   }
 
-  return source;
+  const { date, ...others } = source;
+  return { ...others, date: formatDate(date) };
 }
 
 export default fetchOpenAfricaDatasets;

--- a/src/utils/fetchOpenAfricaDatasets.js
+++ b/src/utils/fetchOpenAfricaDatasets.js
@@ -1,0 +1,66 @@
+import fetchJson from "./fetchJson";
+
+const DATASET_API_PATH = "/api/3/action/package_show?id=";
+const GROUP_API_PATH = "/api/3/action/package_search?fq=groups:";
+
+async function extractDatasets(origin, results) {
+  return results.map((result) => {
+    const {
+      metadata_modified: updatedAt,
+      name,
+      notes: description,
+      title,
+    } = result;
+    const types = result.resources?.map(({ format, url }) => ({
+      href: url,
+      name: format,
+    }));
+    return {
+      date: `Updated: ${new Date(updatedAt).toISOString().substr(0, 10)}`,
+      description,
+      href: `${origin}/dataset/${name}`,
+      title,
+      type: "dataset",
+      types,
+    };
+  });
+}
+
+async function fetchOpenAfricaDatasets(source) {
+  const { href } = source;
+  try {
+    const url = new URL(href);
+    if (
+      process.env.NEXT_PUBLIC_OPENAFRICA_DOMAINS.split(",")
+        .map((d) => d.trim())
+        .includes(url.hostname)
+    ) {
+      const { pathname } = url;
+      let apiPath;
+      if (pathname.startsWith("/dataset/")) {
+        const id = pathname.replace("/dataset/", "").split("/")[0];
+        if (id) {
+          apiPath = `${DATASET_API_PATH}${id}`;
+        }
+      } else if (pathname.startsWith("/group/")) {
+        const groups = pathname.replace("/group/", "").split("/")[0];
+        if (groups) {
+          apiPath = `${GROUP_API_PATH}${groups}`;
+        }
+      }
+      if (apiPath) {
+        const json = await fetchJson(`${url.origin}${apiPath}`);
+        // group datasets are in result.results while individual dataset
+        // is in result
+        const results = json.result.results || [json.result];
+        return extractDatasets(url.origin, results);
+      }
+    }
+  } catch (e) {
+    /* We'll return original source */
+  }
+
+  return source;
+}
+
+export default fetchOpenAfricaDatasets;

--- a/src/utils/fetchSourceAfricaDocuments.js
+++ b/src/utils/fetchSourceAfricaDocuments.js
@@ -1,0 +1,64 @@
+import fetchJson from "./fetchJson";
+
+function formatDate(date) {
+  try {
+    return new Date(date).toISOString().substr(0, 4);
+  } catch (e) {
+    return date || null;
+  }
+}
+
+async function extractDocuments(results) {
+  return results.map((result) => {
+    const {
+      canonical_url: href,
+      description,
+      title,
+      updated_at: updatedAt,
+    } = result;
+    return {
+      date: formatDate(updatedAt),
+      description,
+      href,
+      title,
+    };
+  });
+}
+
+async function fetchSourceAfricaDatasets(source) {
+  const { href } = source;
+  try {
+    const url = new URL(href);
+    if (
+      process.env.NEXT_PUBLIC_SOURCEAFRICA_DOMAINS.split(",")
+        .map((d) => d.trim())
+        .includes(url.hostname)
+    ) {
+      const { pathname } = url;
+      let apiPath;
+      if (pathname.startsWith("/documents/") && pathname.endsWith(".html")) {
+        apiPath = pathname.replace(/\.html$/, ".json");
+      } else if (pathname.startsWith("/search/")) {
+        // Both groups (/search/Group:GGG) and accounts (/search/Account:AAA)
+        const search = pathname.replace(/\/$/, "");
+        // We'll load a maximum of 25 documents from a group
+        apiPath = `/api${search}.json?per_page=25`;
+      }
+      if (apiPath) {
+        const json = await fetchJson(`${url.origin}${apiPath}`);
+        // group documents are in json.documents while individual document
+        // is in json
+        // NOTE: by default,
+        const results = json.documents || [json];
+        return extractDocuments(results);
+      }
+    }
+  } catch (e) {
+    /* We'll return original source */
+  }
+
+  const { date, ...others } = source;
+  return { ...others, date: formatDate(date) };
+}
+
+export default fetchSourceAfricaDatasets;

--- a/src/utils/fetchSourceAfricaDocuments.js
+++ b/src/utils/fetchSourceAfricaDocuments.js
@@ -25,7 +25,7 @@ async function extractDocuments(results) {
   });
 }
 
-async function fetchSourceAfricaDatasets(source) {
+async function fetchSourceAfricaDocuments(source) {
   const { href } = source;
   try {
     const url = new URL(href);
@@ -61,4 +61,4 @@ async function fetchSourceAfricaDatasets(source) {
   return { ...others, date: formatDate(date) };
 }
 
-export default fetchSourceAfricaDatasets;
+export default fetchSourceAfricaDocuments;


### PR DESCRIPTION
## Description

This PR adds ability to

  - [x] Fetch documents datasets information from openAFRICA (and any other CKAN based instance) based on url received from the CMS. CKAN's [Action API](https://docs.ckan.org/en/2.9/api/) is used.
  - [x] Fetch documents  information from sourceAFRICA (and any other DocumentCloud based instance) based on url received from the CMS.
  - [x] Paginate and order documents and datasets.

Closes #102  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![localhost_3000_data_datasets](https://user-images.githubusercontent.com/1779590/134195770-44ece52a-a8ab-4a70-adf3-0c0d0a19bb06.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

