### PR TITLE
[HotFix] Update embed chart ratio

### DIFF
--- a/src/components/ExplorePage/index.js
+++ b/src/components/ExplorePage/index.js
@@ -24,7 +24,6 @@ const useStyles = makeStyles(
         position: "fixed",
         left: 0,
         right: 0,
-        top: 110,
       },
       "& .tooltipPop": {
         background: palette.background.default,

--- a/src/components/HURUmap/IndicatorTitle/Share.js
+++ b/src/components/HURUmap/IndicatorTitle/Share.js
@@ -22,7 +22,7 @@ function Share({ title, geoCode, indicatorId, ...props }) {
     .wrapper {
         position: relative;
         overflow: hidden;
-        padding-top: 60%;
+        padding-top: 75%;
     }
     @media (max-width: 1280px) {
         .wrapper {


### PR DESCRIPTION
## Description

- Update embed chart ratio
- remove redundant top on explore page (nav height has slightly updated after a recent merge.. from 110px to 103px height)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
