### PR TITLE
[Chore] Deploy to dokku on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,25 +1,29 @@
-name: Dokku CD
+---
+name: "deploy"
+
+# yamllint disable-line rule:truthy
 on:
   push:
-    branches: [v1]
-env:
-  DOKKU_APP_NAME: "pesayetu-dev"
-  DOKKU_HOST: "dokku-1.hurumap.org"
-  DOKKU_REMOTE_BRANCH: "master"
-  GIT_PUSH_FLAGS: "--force"
+    branches:
+      - main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Cloning repo
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - id: deploy
-        name: Deploy to dokku
-        uses: idoberko2/dokku-deploy-github-action@v1
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          dokku-host: ${{ env.DOKKU_HOST }}
-          app-name: ${{ env.DOKKU_APP_NAME }}
-          remote-branch: ${{ env.DOKKU_REMOTE_BRANCH }}
-          git-push-flags: ${{ env.GIT_PUSH_FLAGS }}
+          git_remote_url: "ssh://dokku@dokku-1.dev.codeforafrica.org/pesayetu"
+          git_push_flags: "--force"
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

Some of the features we're introducing, such as  #127, don't seem to work on Vercel (or any server-less function environment) and hence we need a proper dev instance. This PR (re)introduces deployment to [Dokku](https://dokku.com) on merge to `main`. As a result:

  - [x] https://pesayetu.dev.codeforafrica.org will now point to the PesaYetu app running on our dev instance, and
  - [x] https://pesayetu.preview.codeforafrica.org will then point to Vercel.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
