### PR TITLE
[Hotfix] Undefined chart configuration

### DIFF
--- a/src/components/HURUmap/Chart/Scope/signals.js
+++ b/src/components/HURUmap/Chart/Scope/signals.js
@@ -1,14 +1,10 @@
 import hoverIcon from "@/pesayetu/assets/icons/Component1375.png";
+import { hurumapArgs } from "@/pesayetu/config";
 import theme from "@/pesayetu/theme";
 
 const graphValueTypes = {
   Percentage: "percentage",
   Value: "value",
-};
-
-const formatting = {
-  percentage: ".0%",
-  value: ",.0f",
 };
 
 export default function Signals(
@@ -18,6 +14,8 @@ export default function Signals(
   groups,
   config
 ) {
+  const formatting = hurumapArgs.chartFormatting;
+
   const valueFormatting = config?.types?.Value?.formatting ?? formatting.value;
   const percentageFormatting =
     config?.types?.Percentage?.formatting ?? formatting.percentage;

--- a/src/components/HURUmap/Chart/Scope/signals.js
+++ b/src/components/HURUmap/Chart/Scope/signals.js
@@ -6,6 +6,11 @@ const graphValueTypes = {
   Value: "value",
 };
 
+const formatting = {
+  percentage: ".0%",
+  value: ",.0f",
+};
+
 export default function Signals(
   chartType,
   filterSignals,
@@ -13,17 +18,16 @@ export default function Signals(
   groups,
   config
 ) {
-  const {
-    defaultType,
-    types: {
-      Value: { formatting: valueFormatting, minX: valueMinX, maxX: valueMaxX },
-      Percentage: {
-        formatting: percentageFormatting,
-        minX: percentageMinX,
-        maxX: percentageMaxX,
-      },
-    },
-  } = config;
+  const valueFormatting = config?.types?.Value?.formatting ?? formatting.value;
+  const percentageFormatting =
+    config?.types?.Percentage?.formatting ?? formatting.percentage;
+
+  const valueMaxX = config?.types?.Value?.maxX ?? undefined;
+  const valueMinX = config?.types?.Value?.minX ?? undefined;
+  const percentageMinX = config?.types?.Percentage?.maxX ?? undefined;
+  const percentageMaxX = config?.types?.Percentage?.minX ?? undefined;
+
+  const defaultType = config?.defaultType ?? "Value";
 
   return [
     {
@@ -56,7 +60,7 @@ export default function Signals(
     },
     {
       name: "Units",
-      value: graphValueTypes[defaultType || "Value"],
+      value: graphValueTypes[defaultType],
     },
     {
       name: "applyFilter",
@@ -74,11 +78,11 @@ export default function Signals(
     },
     {
       name: "percentageFormatting",
-      value: percentageFormatting || ".0%",
+      value: percentageFormatting,
     },
     {
       name: "valueFormatting",
-      value: valueFormatting || ",.0f",
+      value: valueFormatting,
     },
     {
       name: "trimZeroFormat",

--- a/src/components/HURUmap/Chart/index.js
+++ b/src/components/HURUmap/Chart/index.js
@@ -60,13 +60,14 @@ function Chart({
     id,
     description,
     metadata: { source, url, groups, primary_group: primaryGroup },
-    chart_configuration: {
-      disableToggle,
-      defaultType,
-      filter,
-      stacked_field: stackedField,
-    },
   } = indicator;
+
+  const {
+    disableToggle,
+    defaultType,
+    filter,
+    stacked_field: stackedField,
+  } = indicator?.chart_configuration || {};
 
   const [chartValue, setChartValue] = useState(defaultType || "Value");
 
@@ -98,7 +99,7 @@ function Chart({
             title={value.group}
             value={value.count}
             formattedValue={
-              defaultType.toLowerCase() === "percentage" || !disableToggle
+              defaultType?.toLowerCase() === "percentage" || !disableToggle
                 ? value.percentage
                 : undefined
             }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -886,6 +886,10 @@ export const hurumapArgs = {
       fileTypes: ["CSV", "XLSX", "JSON"],
     },
   },
+  chartFormatting: {
+    percentage: ".0%",
+    value: ",.0f",
+  },
 };
 
 export const hurumap = {


### PR DESCRIPTION
## Description

- [Chart_configuration](https://openup.gitbook.io/wazi-ng-technical/profile-indicator-configuration) is optional on back-end, this PR handles undefined `chart_configuration`.

To test, remove `chart_configuration` object on stories

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
