### PR TITLE
[Bug] Hide label on smaller rectangle - treemap

### DIFF
--- a/src/components/HURUmap/Chart/DonutChartScope.js
+++ b/src/components/HURUmap/Chart/DonutChartScope.js
@@ -173,6 +173,10 @@ export default function DonutChartScope(
                   innerRadius: { signal: "innerRadius" },
                   outerRadius: { signal: "donutSize / 4" },
                   cornerRadius: { signal: "cornerRadius" },
+                  tooltip: {
+                    signal:
+                      "{'group': datum[mainGroup], 'count': format(datum.percentage, numberFormat.percentage)}",
+                  },
                 },
               },
             },
@@ -261,6 +265,10 @@ export default function DonutChartScope(
                   innerRadius: { signal: "innerRadius" },
                   outerRadius: { signal: "donutSize / 4 " },
                   cornerRadius: { signal: "cornerRadius" },
+                  tooltip: {
+                    signal:
+                      "{'group': datum[mainGroup], 'count': format(datum.percentage, numberFormat.percentage)}",
+                  },
                 },
               },
             },

--- a/src/components/HURUmap/Chart/TreemapChartScope.js
+++ b/src/components/HURUmap/Chart/TreemapChartScope.js
@@ -63,6 +63,14 @@ export default function TreemapChartScope(
           name: "nestedFields",
           value: nestedFields,
         },
+        {
+          name: "percentageAverage",
+          update: "100 / data('primary_formatted').length",
+        },
+        {
+          name: "secondaryPercentageAverage",
+          update: "100 / data('secondary_formatted').length",
+        },
       ],
       scales: [
         {
@@ -152,11 +160,11 @@ export default function TreemapChartScope(
                 update: {
                   align: { value: "left" },
                   baseline: { value: "top" },
-                  x: { signal: "datum.x0 + 15" },
-                  y: { signal: "datum.y0 + 20" },
+                  x: { signal: "datum.x0 + 12" },
+                  y: { signal: "datum.y0 + 15" },
                   text: {
                     signal:
-                      "[format(datum[datatype[Units]], numberFormat[Units]), datum[mainGroup], datum[nestedFields[1]] || '', datum[nestedFields[2]] || '' ]",
+                      "datum.percentage * 100 < percentageAverage ? '': [format(datum[datatype[Units]], numberFormat[Units]), datum[mainGroup], datum[nestedFields[1]] || '', datum[nestedFields[2]] || '' ]",
                   },
                 },
               },
@@ -229,11 +237,11 @@ export default function TreemapChartScope(
                 update: {
                   align: { value: "left" },
                   baseline: { value: "top" },
-                  x: { signal: "datum.x0 + 15" },
-                  y: { signal: "datum.y0 + 20" },
+                  x: { signal: "datum.x0 + 12" },
+                  y: { signal: "datum.y0 + 15" },
                   text: {
                     signal:
-                      "[format(datum[datatype[Units]], numberFormat[Units]), datum[mainGroup], datum[nestedFields[1]] || '', datum[nestedFields[2]] || '' ]",
+                      "datum.percentage * 100 < secondaryPercentageAverage ? '': [format(datum[datatype[Units]], numberFormat[Units]), datum[mainGroup], datum[nestedFields[1]] || '', datum[nestedFields[2]] || '' ]",
                   },
                 },
               },

--- a/src/components/HURUmap/Chart/utils.js
+++ b/src/components/HURUmap/Chart/utils.js
@@ -1,4 +1,10 @@
-import slugify from "@/pesayetu/utils/slugify";
+const idify = (string) => {
+  return string
+    .replace(/^\s+|\s+$/g, "")
+    .replace(/[^a-z0-9]/g, "")
+    .replace(/\s+/g, "_")
+    .replace(/_+/g, "_");
+};
 /**
  * createFiltersForGroups
  * this method creates the filter for the data transformations as well as the signals that drive the filter. we can set signals from outside to set the filter. we use two signals, one to indicate if the filter is active (we can have multiple filters) the second is the value we filter for.
@@ -10,7 +16,7 @@ export const createFiltersForGroups = (groups) => {
   const signals = new Map();
   groups.forEach((group) => {
     const { name } = group;
-    const keyName = slugify(name);
+    const keyName = idify(name);
     filters.set(keyName, {
       type: "filter",
       expr: `!${keyName}Filter || (${keyName}Filter && datum["${name}"] === ${keyName}FilterValue)`,

--- a/src/components/HURUmap/Panel/formatProfileDataIntoArray.js
+++ b/src/components/HURUmap/Panel/formatProfileDataIntoArray.js
@@ -35,11 +35,13 @@ export default function formatProfileDataIntoArray(data, parent) {
               return {
                 ...m,
                 parentName: parent?.name ?? null,
-                parentMetric: parent.data
-                  ? parent?.data[label]?.subcategories[child]?.key_metrics[
-                      index
-                    ] ?? null
-                  : null,
+                parentMetric:
+                  parent.data &&
+                  parent?.data[label]?.subcategories[child]?.key_metrics
+                    ? parent?.data[label]?.subcategories[child]?.key_metrics[
+                        index
+                      ] ?? null
+                    : null,
               };
             }
           ),

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -4,9 +4,9 @@
  */
 export default function slugify(string) {
   const a =
-    "àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/,:;";
+    "àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·_/,:;";
   const b =
-    "aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz-----";
+    "aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------";
   const p = new RegExp(a.split("").join("|"), "g");
 
   return string


### PR DESCRIPTION
## Description
 - Hide labels for smaller rectangles on treemap
 - Use `idify` function instead of `slugify`
 - update data check

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
### Bug
![Screenshot from 2021-11-09 18-03-52](https://user-images.githubusercontent.com/7962097/140950333-c09570b7-5be8-45f4-8208-358555c16f7c.png)
### Fix
![Screenshot from 2021-11-09 18-01-53](https://user-images.githubusercontent.com/7962097/140950338-b4002ccc-bcbf-4a66-ae81-e8c5fe3c7664.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
