### PR TITLE
Hide empty categories subcategories

### DIFF
--- a/src/components/ExplorePage/index.js
+++ b/src/components/ExplorePage/index.js
@@ -102,7 +102,7 @@ function initializer({ profiles, options }) {
 
   return {
     isPinning: false,
-    isCompare: primary && secondary,
+    isCompare: !!(primary && secondary),
     primary: extendProfileTags(primary, primaryOptions),
     secondary: extendProfileTags(secondary, secondaryOptions),
   };

--- a/src/components/HURUmap/Chart/BarChartScope.js
+++ b/src/components/HURUmap/Chart/BarChartScope.js
@@ -249,6 +249,7 @@ export default function BarChartScope(
                     signal: "data('secondary').length > 1 ? 0 : height + 28 ",
                   },
                   legendX: { signal: "-width/2 - 30" },
+                  labelLimit: 400,
                   fill: "legend_secondary_scale",
                   labelFontWeight: "bold",
                   labelColor: isCompare ? "#666" : "transparent",

--- a/src/components/HURUmap/Chart/DonutChartScope.js
+++ b/src/components/HURUmap/Chart/DonutChartScope.js
@@ -17,6 +17,18 @@ export default function DonutChartScope(
 ) {
   const { primary_group: primaryGroup } = metadata;
 
+  const secondaryLegend = isCompare
+    ? [
+        {
+          orient: "top",
+          fill: "legend_secondary_scale",
+          labelFontWeight: "bold",
+          labelColor: "#666",
+          labelFont: theme.typography.fontFamily,
+        },
+      ]
+    : [];
+
   return merge(
     Scope(
       primaryData,
@@ -205,46 +217,40 @@ export default function DonutChartScope(
               },
             },
           },
-          legends: isCompare
-            ? [
-                {
-                  orient: "top",
-                  fill: "legend_secondary_scale",
-                  labelFontWeight: "bold",
-                  labelColor: "#666",
-                  labelFont: theme.typography.fontFamily,
-                },
-                {
-                  fill:
-                    secondaryData?.length > 1 ? "secondary" : "empty_legend",
-                  stroke: "secondary",
-                  orient: "none",
-                  symbolType: "circle",
-                  direction: "vertical",
-                  labelFont: theme.typography.fontFamily,
-                  legendX: { signal: "donutSize / 2 + 40" },
-                  legendY: 40,
-                  labelOffset: 12,
-                  rowPadding: 8,
-                  encode: {
-                    labels: {
-                      interactive: true,
-                      update: {
-                        fontSize: { value: 11 },
-                        fill: { value: theme.palette.chart.text.primary },
+          legends:
+            secondaryData?.length > 1
+              ? [
+                  ...secondaryLegend,
+                  {
+                    fill: "secondary",
+                    stroke: "secondary",
+                    orient: "none",
+                    symbolType: "circle",
+                    direction: "vertical",
+                    labelFont: theme.typography.fontFamily,
+                    legendX: { signal: "donutSize / 2 + 40" },
+                    legendY: 40,
+                    labelOffset: 12,
+                    rowPadding: 8,
+                    encode: {
+                      labels: {
+                        interactive: true,
+                        update: {
+                          fontSize: { value: 11 },
+                          fill: { value: theme.palette.chart.text.primary },
+                        },
                       },
-                    },
-                    symbols: {
-                      enter: {
-                        fillOpacity: {
-                          value: 1,
+                      symbols: {
+                        enter: {
+                          fillOpacity: {
+                            value: 1,
+                          },
                         },
                       },
                     },
                   },
-                },
-              ]
-            : null,
+                ]
+              : secondaryLegend,
           marks: [
             {
               type: "arc",

--- a/src/components/HURUmap/Chart/DonutChartScope.js
+++ b/src/components/HURUmap/Chart/DonutChartScope.js
@@ -23,6 +23,7 @@ export default function DonutChartScope(
           orient: "top",
           fill: "legend_secondary_scale",
           labelFontWeight: "bold",
+          labelLimit: 400,
           labelColor: "#666",
           labelFont: theme.typography.fontFamily,
         },

--- a/src/components/HURUmap/Chart/LineChartScope.js
+++ b/src/components/HURUmap/Chart/LineChartScope.js
@@ -325,7 +325,7 @@ export default function LineChartScope(
               },
               y: {
                 signal:
-                  "isMobile && data('secondary').length > 1 ? height/2 + 60: data('secondary').length > 1 ? chartY: height + 40",
+                  "isMobile && data('secondary').length > 1 ? height/2 + 60: data('secondary').length > 1 ? chartY: height + 60",
               },
               height: {
                 signal:

--- a/src/components/HURUmap/Chart/LineChartScope.js
+++ b/src/components/HURUmap/Chart/LineChartScope.js
@@ -343,6 +343,7 @@ export default function LineChartScope(
                   orient: "top",
                   fill: "legend_secondary_scale",
                   labelFontWeight: "bold",
+                  labelLimit: 400,
                   labelColor: "#666",
                   labelFont: theme.typography.fontFamily,
                 },

--- a/src/components/HURUmap/Chart/StackedChartScope.js
+++ b/src/components/HURUmap/Chart/StackedChartScope.js
@@ -10,12 +10,31 @@ export default function StackedChartScope(
   config,
   secondaryData,
   primaryParentData,
-  secondaryParentData
+  secondaryParentData,
+  profileNames,
+  isCompare
 ) {
   const { xTicks, parentLabel } = config;
 
   const { primary_group: primaryGroup } = metadata;
   const stackedField = config.stacked_field;
+
+  const secondaryLegend = [
+    {
+      orient: {
+        value: "none",
+      },
+      legendY: {
+        signal: "height + 30 ",
+      },
+      labelLimit: 400,
+      legendX: { signal: "-width/2 - 30" },
+      fill: "legend_secondary_scale",
+      labelFontWeight: "bold",
+      labelColor: "#666",
+      labelFont: theme.typography.fontFamily,
+    },
+  ];
 
   return merge(
     Scope(
@@ -102,6 +121,18 @@ export default function StackedChartScope(
             data: "primary_formatted",
             field: stackedField,
           },
+        },
+        {
+          name: "legend_primary_scale",
+          type: "ordinal",
+          domain: [profileNames.primary.toUpperCase()],
+          range: [theme.palette.primary.main],
+        },
+        {
+          name: "legend_secondary_scale",
+          type: "ordinal",
+          domain: [profileNames.secondary.toUpperCase()],
+          range: [theme.palette.secondary.main],
         },
         {
           name: "parent_color_scale",
@@ -281,8 +312,9 @@ export default function StackedChartScope(
             },
           ],
           legends:
-            secondaryData?.length > 1
+            isCompare && secondaryData?.length > 1
               ? [
+                  ...secondaryLegend,
                   {
                     fill: "secondary_color",
                     orient: "top",
@@ -305,7 +337,7 @@ export default function StackedChartScope(
                     },
                   },
                 ]
-              : null,
+              : secondaryLegend,
           marks: [
             {
               name: "secondary_bars",

--- a/src/components/HURUmap/Chart/TreemapChartScope.js
+++ b/src/components/HURUmap/Chart/TreemapChartScope.js
@@ -197,6 +197,7 @@ export default function TreemapChartScope(
                   labelFontWeight: "bold",
                   labelColor: "#666",
                   labelFont: theme.typography.fontFamily,
+                  labelLimit: 400,
                 },
               ]
             : null,

--- a/src/components/HURUmap/Chart/TreemapChartScope.js
+++ b/src/components/HURUmap/Chart/TreemapChartScope.js
@@ -38,7 +38,10 @@ export default function TreemapChartScope(
           method: { signal: "layout" },
           ratio: { signal: "aspectRatio" },
           size: [
-            { signal: "isCompare && !isMobile ? width/2 -30: width" },
+            {
+              signal:
+                "isCompare && data('secondary').length > 1 && !isMobile ? width/2 -30: width",
+            },
             { signal: "isCompare && isMobile ? height/2 : height" },
           ],
         },
@@ -107,14 +110,6 @@ export default function TreemapChartScope(
             update: {
               x: { value: 0 },
               y: { signal: "chartY" },
-              height: {
-                signal:
-                  "isMobile && isCompare && data('secondary').length > 1 ? height/2: height",
-              },
-              width: {
-                signal:
-                  "isMobile && data('secondary').length > 1 ? width : width/2",
-              },
             },
           },
           legends: isCompare

--- a/src/components/HURUmap/Chart/configureScope.js
+++ b/src/components/HURUmap/Chart/configureScope.js
@@ -82,7 +82,9 @@ export default function configureScope(
           configuration,
           secondaryIndicator?.data ?? null,
           showParent ? indicator?.parentData : [{}],
-          showParent ? secondaryIndicator?.parentData : [{}]
+          showParent ? secondaryIndicator?.parentData : [{}],
+          profileNames,
+          isCompare
         );
       }
       break;

--- a/src/components/HURUmap/Panel/DesktopPanel/index.js
+++ b/src/components/HURUmap/Panel/DesktopPanel/index.js
@@ -1,7 +1,7 @@
 import { Drawer } from "@material-ui/core";
 import clsx from "clsx";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import PanelItem from "./PanelItem";
 import useStyles from "./useStyles";
@@ -15,14 +15,32 @@ function DesktopPanel({
   onClickPin,
   onClickUnpin,
   panelItems: panelItemsProp,
+  primaryProfile,
   ...props
 }) {
-  const [value, setValue] = React.useState();
-  const [pins, setPins] = React.useState([]);
-  const [panelItems, setPanelItems] = React.useState(panelItemsProp);
-  const paperRef = React.useRef();
+  const [value, setValue] = useState();
+  const [pins, setPins] = useState([]);
+  const [panelItems, setPanelItems] = useState([]);
+  const paperRef = useRef();
   const drawerWidth = paperRef.current?.clientWidth;
   const classes = useStyles({ ...props, drawerWidth });
+
+  useEffect(() => {
+    const pItems =
+      panelItemsProp?.map((x) => {
+        if (
+          (x?.value === "rich-data" || x?.value === "pin") &&
+          primaryProfile?.items?.length === 0
+        ) {
+          return {
+            ...x,
+            disabled: true,
+          };
+        }
+        return x;
+      }) ?? [];
+    setPanelItems(pItems);
+  }, [panelItemsProp, primaryProfile.items]);
 
   useEffect(() => {
     setPanelItems((pi) => {
@@ -126,6 +144,7 @@ function DesktopPanel({
             onClickUnpin={onClickUnpin}
             isPinning={isPinning}
             onClickPin={onClickPin}
+            primaryProfile={primaryProfile}
             {...props}
           />
         </TabPanel>
@@ -157,6 +176,9 @@ DesktopPanel.propTypes = {
       tree: PropTypes.shape({}),
     })
   ),
+  primaryProfile: PropTypes.shape({
+    items: PropTypes.arrayOf(PropTypes.shape({})),
+  }),
 };
 
 DesktopPanel.defaultProps = {
@@ -165,6 +187,7 @@ DesktopPanel.defaultProps = {
   onClickPin: undefined,
   onClickUnpin: undefined,
   panelItems: undefined,
+  primaryProfile: undefined,
 };
 
 export default DesktopPanel;

--- a/src/components/HURUmap/Panel/DesktopPanel/index.js
+++ b/src/components/HURUmap/Panel/DesktopPanel/index.js
@@ -39,26 +39,22 @@ function DesktopPanel({
         }
         return x;
       }) ?? [];
-    setPanelItems(pItems);
-  }, [panelItemsProp, primaryProfile.items]);
 
-  useEffect(() => {
-    setPanelItems((pi) => {
-      const foundCompare = pi?.find((item) => item.value === "secondaryPin");
-      if (isCompare && !foundCompare) {
-        const pinItems = pi?.find((i) => i.value === "pin");
+    if (isCompare) {
+      const foundCompare = pItems?.find(
+        (item) => item.value === "secondaryPin"
+      );
+      if (!foundCompare) {
+        const pinIndex = pItems?.findIndex((i) => i?.value === "pin");
         const secondaryPin = {
-          ...pinItems,
+          ...pItems[pinIndex],
           value: "secondaryPin",
         };
-        return [...pi, secondaryPin];
+        pItems.splice(pinIndex + 1, 0, secondaryPin);
       }
-      if (!isCompare && foundCompare) {
-        return pi?.filter((p) => p?.value !== "secondaryPin");
-      }
-      return pi;
-    });
-  }, [isCompare]);
+    }
+    setPanelItems(pItems);
+  }, [isCompare, panelItemsProp, primaryProfile.items]);
 
   useEffect(() => {
     if (isPinning || isCompare) {

--- a/src/components/HURUmap/Panel/formatProfileDataIntoArray.js
+++ b/src/components/HURUmap/Panel/formatProfileDataIntoArray.js
@@ -4,49 +4,59 @@ export default function formatProfileDataIntoArray(data, parent) {
   if (!data) {
     return null;
   }
-  return Object.keys(data).map((label) => {
-    return {
-      title: label,
-      icon: data[label].icon ?? defaultIcon,
-      description: data[label].description,
-      children: Object.keys(data[label]?.subcategories).map((child) => {
-        return {
-          title: child,
-          description: data[label]?.subcategories[child].description,
-          children: Object.keys(
-            data[label]?.subcategories[child]?.indicators ?? []
-          ).map((indicator) => {
+  return Object.keys(data)
+    .map((label) => {
+      return {
+        title: label,
+        icon: data[label].icon ?? defaultIcon,
+        description: data[label].description,
+        children: Object.keys(data[label]?.subcategories)
+          .map((child) => {
             return {
-              index: `${indicator}-${data[label]?.subcategories[child]?.indicators[indicator]?.id}`,
-              title: indicator,
-              indicator: {
-                ...data[label]?.subcategories?.[child]?.indicators?.[indicator],
-                parentData: parent.data
-                  ? parent?.data?.[label]?.subcategories?.[child]?.indicators?.[
-                      indicator
-                    ]?.data ?? null
-                  : null,
-                parentName: parent?.name ?? null,
-              },
+              title: child,
+              description: data[label]?.subcategories[child].description,
+              children: Object.keys(
+                data[label]?.subcategories[child]?.indicators ?? []
+              )
+                .map((indicator) => {
+                  return {
+                    index: `${indicator}-${data[label]?.subcategories[child]?.indicators[indicator]?.id}`,
+                    title: indicator,
+                    indicator: {
+                      ...data[label]?.subcategories?.[child]?.indicators?.[
+                        indicator
+                      ],
+                      parentData: parent.data
+                        ? parent?.data?.[label]?.subcategories?.[child]
+                            ?.indicators?.[indicator]?.data ?? null
+                        : null,
+                      parentName: parent?.name ?? null,
+                    },
+                  };
+                })
+                .filter((indic) => indic.indicator),
+              metrics: (
+                data[label]?.subcategories[child]?.key_metrics ?? []
+              ).map((m, index) => {
+                return {
+                  ...m,
+                  parentName: parent?.name ?? null,
+                  parentMetric:
+                    parent.data &&
+                    parent?.data[label]?.subcategories[child]?.key_metrics
+                      ? parent?.data[label]?.subcategories[child]?.key_metrics[
+                          index
+                        ] ?? null
+                      : null,
+                };
+              }),
             };
-          }),
-          metrics: (data[label]?.subcategories[child]?.key_metrics ?? []).map(
-            (m, index) => {
-              return {
-                ...m,
-                parentName: parent?.name ?? null,
-                parentMetric:
-                  parent.data &&
-                  parent?.data[label]?.subcategories[child]?.key_metrics
-                    ? parent?.data[label]?.subcategories[child]?.key_metrics[
-                        index
-                      ] ?? null
-                    : null,
-              };
-            }
+          })
+          .filter(
+            (subcategory) =>
+              subcategory.metrics.length || subcategory.metrics.length
           ),
-        };
-      }),
-    };
-  });
+      };
+    })
+    .filter((category) => category.children.length);
 }

--- a/src/components/HURUmap/Panel/index.js
+++ b/src/components/HURUmap/Panel/index.js
@@ -9,9 +9,6 @@ import MobilePanel from "./MobilePanel";
 function Panel({ primaryProfile, secondaryProfile, ...props }) {
   const primaryItems = formatData(primaryProfile?.data, primaryProfile?.parent);
 
-  if (!primaryItems?.length) {
-    return null;
-  }
   const formatedPrimaryProfile = {
     ...primaryProfile,
     items: primaryItems,

--- a/src/config/profile.js
+++ b/src/config/profile.js
@@ -47847,7 +47847,6 @@ export default {
         ],
       },
     ],
-    themes: [],
   },
   highlights: [],
   overview: {

--- a/src/utils/fetchProfile.js
+++ b/src/utils/fetchProfile.js
@@ -6,8 +6,8 @@ async function fetchProfile(apiUri, geoCode) {
   const json = await fetchJson(
     `${apiUri}all_details/profile/1/geography/${geoCode.toUpperCase()}/?format=json`
   );
-  const { boundary, children, parent_layers: parents, themes } = json;
-  const geometries = { boundary, children, parents, themes };
+  const { boundary, children, parent_layers: parents } = json;
+  const geometries = { boundary, children, parents };
   const {
     profile_data: data,
     highlights: originalHighlights,


### PR DESCRIPTION
## Description
- Hide subcategories with no indicator data, and categories with no subcategories
- Disable `rich-data` & `pin` for geography with no profile data on desktop. (Note: geography with no profile data can still be compared with another  geography i.e it can be selected as a secondary profile, but it cannot be primary geography when comparison)
<img width="1001" alt="Screenshot 2022-01-14 at 15 11 16" src="https://user-images.githubusercontent.com/7962097/149513659-94c01751-817d-4f30-b99e-5b030698961c.png">

- Minor fix on donut legend for comparison

Bug 
<img width="801" alt="Screenshot 2022-01-14 at 12 47 04" src="https://user-images.githubusercontent.com/7962097/149512147-ef9a30fc-7292-4fd9-a026-1ef3ea7e4fcb.png">
Fix
<img width="801" alt="Screenshot 2022-01-14 at 14 41 10" src="https://user-images.githubusercontent.com/7962097/149512220-fda160b3-b39c-4f6a-9a08-f9e51b72e01d.png">

Test Charts:
-  `/explore/47`
-  `/explore/47-vs-8`
-   `/explore/47-vs-47`

Fixes # (issue)
## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
