### PR TITLE
[Fix] indicator matching discrepancy

### DIFF
--- a/src/components/HURUmap/Chart/StackedChartScope.js
+++ b/src/components/HURUmap/Chart/StackedChartScope.js
@@ -19,22 +19,24 @@ export default function StackedChartScope(
   const { primary_group: primaryGroup } = metadata;
   const stackedField = config.stacked_field;
 
-  const secondaryLegend = [
-    {
-      orient: {
-        value: "none",
-      },
-      legendY: {
-        signal: "height + 30 ",
-      },
-      labelLimit: 400,
-      legendX: { signal: "-width/2 - 30" },
-      fill: "legend_secondary_scale",
-      labelFontWeight: "bold",
-      labelColor: "#666",
-      labelFont: theme.typography.fontFamily,
-    },
-  ];
+  const secondaryLegend = isCompare
+    ? [
+        {
+          orient: {
+            value: "none",
+          },
+          legendY: {
+            signal: "height + 30 ",
+          },
+          labelLimit: 400,
+          legendX: { signal: "-width/2 - 30" },
+          fill: "legend_secondary_scale",
+          labelFontWeight: "bold",
+          labelColor: "#666",
+          labelFont: theme.typography.fontFamily,
+        },
+      ]
+    : null;
 
   return merge(
     Scope(

--- a/src/components/HURUmap/Panel/Profile.js
+++ b/src/components/HURUmap/Panel/Profile.js
@@ -132,11 +132,13 @@ const Profile = forwardRef(function Profile(
   const getSecondaryIndicator = (
     categoryIndex,
     subcategoryIndex,
-    indicatorIndex
+    indicatorId
   ) => {
     const category = secondaryProfile?.items?.[categoryIndex];
     const subCategory = category?.children?.[subcategoryIndex];
-    const indicator = subCategory?.children?.[indicatorIndex];
+    const indicator = subCategory?.children?.find(
+      ({ indicator: { id } }) => indicatorId === id
+    );
     return indicator;
   };
 
@@ -194,7 +196,7 @@ const Profile = forwardRef(function Profile(
                 id={slugify(child.title)}
                 title={child.title}
               />
-              {child.children.map(({ index, ...indicator }, indicatorIndex) => (
+              {child.children.map(({ index, ...indicator }) => (
                 <Chart
                   key={index}
                   variant="primary"
@@ -203,7 +205,7 @@ const Profile = forwardRef(function Profile(
                   secondaryIndicator={getSecondaryIndicator(
                     categoryIndex,
                     subcategoryIndex,
-                    indicatorIndex
+                    indicator.indicator.id
                   )}
                   isCompare={!!secondaryProfile}
                   profileNames={{
@@ -215,7 +217,7 @@ const Profile = forwardRef(function Profile(
                       getSecondaryIndicator(
                         categoryIndex,
                         subcategoryIndex,
-                        indicatorIndex
+                        indicator.indicator.id
                       )?.indicator?.data?.length > 0
                         ? secondaryProfile?.geography?.name
                         : `${secondaryProfile?.geography?.name} ${dataNotAvailable}`,

--- a/src/components/HURUmap/Panel/formatProfileDataIntoArray.js
+++ b/src/components/HURUmap/Panel/formatProfileDataIntoArray.js
@@ -54,7 +54,7 @@ export default function formatProfileDataIntoArray(data, parent) {
           })
           .filter(
             (subcategory) =>
-              subcategory.metrics.length || subcategory.metrics.length
+              subcategory.children.length || subcategory.metrics.length
           ),
       };
     })


### PR DESCRIPTION
## Description

- As datasets/indicators' geographies differ...the initial solution of matching indicator position index between two profiles does not work. This PR match `indicator ids` instead of `indicator position`

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
