### PR TITLE
[Fix] Sorting donut chart + axis ticks count

### DIFF
--- a/src/components/HURUmap/Chart/BarChartScope.js
+++ b/src/components/HURUmap/Chart/BarChartScope.js
@@ -34,6 +34,28 @@ export default function BarChartScope(
           name: "height",
           update: "bandspace(domain('yscale').length, 0.1, 0.05) * y_step",
         },
+        {
+          name: "xTicks",
+          value: xTicks || 6,
+        },
+        {
+          name: "maxXScaleValue",
+          update: "extent(domain('xscale'))[1]",
+        },
+        {
+          name: "maxXSecondaryScaleValue",
+          update: "extent(domain('s_xscale'))[1]",
+        },
+        // if the maximum value of xaxis is less than xTicks return maximum value as tick Count
+        {
+          name: "primaryTickCount",
+          update: "maxXScaleValue < xTicks ? maxXScaleValue : xTicks",
+        },
+        {
+          name: "secondaryTickCount",
+          update:
+            "maxXSecondaryScaleValue < xTicks ? maxXSecondaryScaleValue : xTicks",
+        },
       ],
       scales: [
         {
@@ -55,7 +77,7 @@ export default function BarChartScope(
               signal: "data('secondary').length > 1 ? width/2 - 30 : width",
             },
           ],
-          nice: xTicks || 6,
+          nice: { signal: "primaryTickCount" },
           zero: true,
           domain: {
             data: "primary_formatted",
@@ -71,7 +93,7 @@ export default function BarChartScope(
               signal: "data('secondary').length > 1 ? width/2 - 30 : 0",
             },
           ],
-          nice: xTicks || 6,
+          nice: { signal: "secondaryTickCount" },
           zero: true,
           domain: {
             data: "secondary_formatted",
@@ -141,7 +163,7 @@ export default function BarChartScope(
               format: { signal: "numberFormat[Units]" },
               grid: true,
               labelPadding: 6,
-              tickCount: xTicks || 6,
+              tickCount: { signal: "primaryTickCount" },
             },
           ],
           marks: [
@@ -268,7 +290,7 @@ export default function BarChartScope(
               format: { signal: "numberFormat[Units]" },
               grid: true,
               labelPadding: 6,
-              tickCount: xTicks || 6,
+              tickCount: { signal: "secondaryTickCount" },
             },
           ],
 

--- a/src/components/HURUmap/Chart/BarChartScope.js
+++ b/src/components/HURUmap/Chart/BarChartScope.js
@@ -14,7 +14,7 @@ export default function BarChartScope(
   profileNames,
   isCompare
 ) {
-  const { xTicks, parentLabel } = config;
+  const { parentLabel } = config;
 
   const { primary_group: primaryGroup } = metadata;
 
@@ -33,28 +33,6 @@ export default function BarChartScope(
         {
           name: "height",
           update: "bandspace(domain('yscale').length, 0.1, 0.05) * y_step",
-        },
-        {
-          name: "xTicks",
-          value: xTicks || 6,
-        },
-        {
-          name: "maxXScaleValue",
-          update: "extent(domain('xscale'))[1]",
-        },
-        {
-          name: "maxXSecondaryScaleValue",
-          update: "extent(domain('s_xscale'))[1]",
-        },
-        // if the maximum value of xaxis is less than xTicks return maximum value as tick Count
-        {
-          name: "primaryTickCount",
-          update: "maxXScaleValue < xTicks ? maxXScaleValue : xTicks",
-        },
-        {
-          name: "secondaryTickCount",
-          update:
-            "maxXSecondaryScaleValue < xTicks ? maxXSecondaryScaleValue : xTicks",
         },
       ],
       scales: [
@@ -77,7 +55,7 @@ export default function BarChartScope(
               signal: "data('secondary').length > 1 ? width/2 - 30 : width",
             },
           ],
-          nice: { signal: "primaryTickCount" },
+          nice: { signal: "primaryXTickCount" },
           zero: true,
           domain: {
             data: "primary_formatted",
@@ -93,7 +71,7 @@ export default function BarChartScope(
               signal: "data('secondary').length > 1 ? width/2 - 30 : 0",
             },
           ],
-          nice: { signal: "secondaryTickCount" },
+          nice: { signal: "secondaryXTickCount" },
           zero: true,
           domain: {
             data: "secondary_formatted",
@@ -163,7 +141,7 @@ export default function BarChartScope(
               format: { signal: "numberFormat[Units]" },
               grid: true,
               labelPadding: 6,
-              tickCount: { signal: "primaryTickCount" },
+              tickCount: { signal: "primaryXTickCount" },
             },
           ],
           marks: [
@@ -290,7 +268,7 @@ export default function BarChartScope(
               format: { signal: "numberFormat[Units]" },
               grid: true,
               labelPadding: 6,
-              tickCount: { signal: "secondaryTickCount" },
+              tickCount: { signal: "secondaryXTickCount" },
             },
           ],
 

--- a/src/components/HURUmap/Chart/DonutChartScope.js
+++ b/src/components/HURUmap/Chart/DonutChartScope.js
@@ -52,6 +52,10 @@ export default function DonutChartScope(
           endAngle: { signal: "endAngle" },
           sort: { signal: "sort" },
         },
+        {
+          type: "collect",
+          sort: { field: "count", order: "descending" },
+        },
       ]
     ),
     {
@@ -170,7 +174,6 @@ export default function DonutChartScope(
             {
               type: "arc",
               from: { data: "primary_formatted" },
-              sort: { field: "datum.percentage", order: "ascending" },
               encode: {
                 enter: {
                   fill: { scale: "color", field: { signal: "mainGroup" } },

--- a/src/components/HURUmap/Chart/DonutChartScope.js
+++ b/src/components/HURUmap/Chart/DonutChartScope.js
@@ -170,6 +170,7 @@ export default function DonutChartScope(
             {
               type: "arc",
               from: { data: "primary_formatted" },
+              sort: { field: "datum.percentage", order: "ascending" },
               encode: {
                 enter: {
                   fill: { scale: "color", field: { signal: "mainGroup" } },

--- a/src/components/HURUmap/Chart/LineChartScope.js
+++ b/src/components/HURUmap/Chart/LineChartScope.js
@@ -15,7 +15,7 @@ export default function LineChartScope(
   isCompare,
   isMobile
 ) {
-  const { xTicks, parentLabel } = config;
+  const { parentLabel } = config;
 
   const { primary_group: primaryGroup } = metadata;
 
@@ -84,7 +84,7 @@ export default function LineChartScope(
             field: { signal: "datatype[Units]" },
           },
           range: [{ signal: "isCompare && isMobile ? height/2: height" }, 0],
-          nice: xTicks || 6,
+          nice: { signal: "primaryYTickCount" },
           zero: false,
           clamp: true,
         },
@@ -96,7 +96,7 @@ export default function LineChartScope(
             field: { signal: "datatype[Units]" },
           },
           range: [{ signal: "isCompare && isMobile ? height/2: height" }, 0],
-          nice: xTicks || 6,
+          nice: { signal: "secondaryYTickCount" },
           zero: false,
           clamp: true,
         },
@@ -174,7 +174,7 @@ export default function LineChartScope(
               domain: false,
               domainOpacity: 0.5,
               tickSize: 0,
-              tickCount: xTicks || 6,
+              tickCount: { signal: "primaryYTickCount" },
               labelPadding: 6,
               zindex: 1,
               format: { signal: "numberFormat[Units]" },
@@ -366,7 +366,7 @@ export default function LineChartScope(
                     domain: false,
                     domainOpacity: 0.5,
                     tickSize: 0,
-                    tickCount: xTicks || 6,
+                    tickCount: { signal: "secondaryYTickCount" },
                     labelPadding: 6,
                     zindex: 1,
                     format: { signal: "numberFormat[Units]" },

--- a/src/components/HURUmap/Chart/MultiLineChartScope.js
+++ b/src/components/HURUmap/Chart/MultiLineChartScope.js
@@ -15,7 +15,7 @@ export default function MultiLineChartScope(
   isCompare,
   isMobile
 ) {
-  const { xTicks, parentLabel } = config;
+  const { parentLabel } = config;
 
   const { primary_group: primaryGroup } = metadata;
   const stackedField = config.stacked_field;
@@ -98,7 +98,7 @@ export default function MultiLineChartScope(
             field: { signal: "datatype[Units]" },
           },
           range: [{ signal: "isCompare && isMobile ? height/2: height" }, 0],
-          nice: xTicks || 6,
+          nice: { signal: "primaryYTickCount" },
           zero: false,
           clamp: true,
         },
@@ -110,7 +110,7 @@ export default function MultiLineChartScope(
             field: { signal: "datatype[Units]" },
           },
           range: [{ signal: "isCompare && isMobile ? height/2: height" }, 0],
-          nice: xTicks || 6,
+          nice: { signal: "secondaryYTickCount" },
           zero: false,
           clamp: true,
         },
@@ -217,7 +217,7 @@ export default function MultiLineChartScope(
               domain: false,
               domainOpacity: 0.5,
               tickSize: 0,
-              tickCount: xTicks || 6,
+              tickCount: { signal: "primaryYTickCount" },
               labelPadding: 6,
               zindex: 1,
               format: { signal: "numberFormat[Units]" },
@@ -445,7 +445,7 @@ export default function MultiLineChartScope(
                     domain: false,
                     domainOpacity: 0.5,
                     tickSize: 0,
-                    tickCount: xTicks || 6,
+                    tickCount: { signal: "secondaryYTickCount" },
                     labelPadding: 6,
                     zindex: 1,
                     format: { signal: "numberFormat[Units]" },

--- a/src/components/HURUmap/Chart/Scope/signals.js
+++ b/src/components/HURUmap/Chart/Scope/signals.js
@@ -26,6 +26,8 @@ export default function Signals(
   const percentageMaxX = config?.types?.Percentage?.minX ?? undefined;
 
   const defaultType = config?.defaultType ?? "Value";
+  const xTicks = config?.xTicks ?? 6;
+  const yTicks = config?.yTicks ?? 6;
 
   return [
     {
@@ -172,6 +174,50 @@ export default function Signals(
     {
       name: "aspectRatio",
       value: 1.6,
+    },
+    // tickCount signals
+    {
+      name: "xTicks",
+      value: xTicks,
+    },
+    {
+      name: "yTicks",
+      value: yTicks,
+    },
+    {
+      name: "maxXScaleValue",
+      update: "extent(domain('xscale'))[1]",
+    },
+    {
+      name: "maxYScaleValue",
+      update: "extent(domain('yscale'))[1]",
+    },
+    {
+      name: "maxSecondaryXScaleValue",
+      update: "extent(domain('s_xscale'))[1]",
+    },
+    {
+      name: "maxSecondaryYScaleValue",
+      update: "extent(domain('s_yscale'))[1]",
+    },
+    // if the maximum value of xaxis is less than xTicks return maximum value as tick Count
+    {
+      name: "primaryXTickCount",
+      update: "maxXScaleValue < xTicks ? maxXScaleValue : xTicks",
+    },
+    {
+      name: "primaryYTickCount",
+      update: "maxYScaleValue < yTicks ? maxYScaleValue : yTicks",
+    },
+    {
+      name: "secondaryXTickCount",
+      update:
+        "maxSecondaryXScaleValue < xTicks ? maxSecondaryXScaleValue : xTicks",
+    },
+    {
+      name: "secondaryYTickCount",
+      update:
+        "maxSecondaryYScaleValue < yTicks ? maxSecondaryYScaleValue : yTicks",
     },
     // signals for logo and title => image layout downloads
     { name: "chartY", value: 0 },

--- a/src/components/HURUmap/Chart/StackedChartScope.js
+++ b/src/components/HURUmap/Chart/StackedChartScope.js
@@ -14,7 +14,7 @@ export default function StackedChartScope(
   profileNames,
   isCompare
 ) {
-  const { xTicks, parentLabel } = config;
+  const { parentLabel } = config;
 
   const { primary_group: primaryGroup } = metadata;
   const stackedField = config.stacked_field;
@@ -88,7 +88,7 @@ export default function StackedChartScope(
           ],
           zero: true,
           clamp: true,
-          nice: xTicks || 6,
+          nice: { signal: "primaryXTickCount" },
         },
         {
           name: "s_xscale",
@@ -104,7 +104,7 @@ export default function StackedChartScope(
           ],
           zero: true,
           clamp: true,
-          nice: xTicks || 6,
+          nice: { signal: "secondaryXTickCount" },
         },
         {
           name: "color",
@@ -176,7 +176,7 @@ export default function StackedChartScope(
               format: { signal: "numberFormat[Units]" },
               grid: true,
               labelPadding: 6,
-              tickCount: xTicks || 6,
+              tickCount: { signal: "primaryXTickCount" },
             },
           ],
           legends: [
@@ -311,7 +311,7 @@ export default function StackedChartScope(
               format: { signal: "numberFormat[Units]" },
               grid: true,
               labelPadding: 6,
-              tickCount: xTicks || 6,
+              tickCount: { signal: "secondaryXTickCount" },
             },
           ],
           legends:

--- a/src/components/StoriesPage/index.js
+++ b/src/components/StoriesPage/index.js
@@ -68,7 +68,8 @@ function StoriesPage({
       {page === 1 && <Hero {...hero} />}
       <Section classes={{ root: classes.section }}>
         <Tabs
-          name={activeTab}
+          key={activeCategory}
+          name={activeCategory}
           activeTab={activeTab}
           items={tabItems}
           onChange={handleTabChange}

--- a/src/components/StoriesPage/index.js
+++ b/src/components/StoriesPage/index.js
@@ -68,8 +68,7 @@ function StoriesPage({
       {page === 1 && <Hero {...hero} />}
       <Section classes={{ root: classes.section }}>
         <Tabs
-          key={activeTab}
-          name="stories"
+          name={activeTab}
           activeTab={activeTab}
           items={tabItems}
           onChange={handleTabChange}

--- a/src/components/StoriesPage/index.js
+++ b/src/components/StoriesPage/index.js
@@ -68,6 +68,7 @@ function StoriesPage({
       {page === 1 && <Hero {...hero} />}
       <Section classes={{ root: classes.section }}>
         <Tabs
+          key={activeTab}
           name="stories"
           activeTab={activeTab}
           items={tabItems}

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -82,7 +82,7 @@ Tabs.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
-      children: PropTypes.string,
+      children: PropTypes.node,
     })
   ),
   onChange: PropTypes.func,


### PR DESCRIPTION
## Description
- Sort donut chart in descending order
- Update `tickCount` for chart with scale value less than ticks count
- Add key to stories tab

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
### Bug
https://user-images.githubusercontent.com/7962097/156136389-db6d790d-735d-475f-ac63-9d8ac9985bd3.mov

<img width="658" alt="Screenshot 2022-03-01 at 11 53 31" src="https://user-images.githubusercontent.com/7962097/156137782-290200e8-336d-45a7-8f0e-8ea65c4db676.png">

### Fix
https://user-images.githubusercontent.com/7962097/156136508-ba216953-c6e2-469b-9fa1-8a1252bae081.mov


<img width="658" alt="Screenshot 2022-03-01 at 11 59 09" src="https://user-images.githubusercontent.com/7962097/156137830-d0e31f45-0cc8-4932-ac64-92721136c86b.png">



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
