### PR TITLE
[Fix] Add label flush on line charts

### DIFF
--- a/src/components/HURUmap/Chart/LineChartScope.js
+++ b/src/components/HURUmap/Chart/LineChartScope.js
@@ -215,6 +215,8 @@ export default function LineChartScope(
               tickSize: 0,
               grid: true,
               labelPadding: 6,
+              labelFlush: true,
+              labelOverlap: true,
               formatType: xScaleType,
               format:
                 (isMobile ? xScaleMobileFormat : xScaleFormat) || undefined,
@@ -410,6 +412,8 @@ export default function LineChartScope(
                     tickSize: 0,
                     grid: true,
                     labelPadding: 6,
+                    labelFlush: true,
+                    labelOverlap: true,
                     formatType: xScaleType,
                     format:
                       (isMobile ? xScaleMobileFormat : xScaleFormat) ||

--- a/src/components/HURUmap/Chart/MultiLineChartScope.js
+++ b/src/components/HURUmap/Chart/MultiLineChartScope.js
@@ -257,6 +257,8 @@ export default function MultiLineChartScope(
               tickSize: 0,
               grid: true,
               labelPadding: 6,
+              labelFlush: true,
+              labelOverlap: true,
               formatType: xScaleType,
               format:
                 (isMobile ? xScaleMobileFormat : xScaleFormat) || undefined,
@@ -488,6 +490,8 @@ export default function MultiLineChartScope(
                     tickSize: 0,
                     grid: true,
                     labelPadding: 6,
+                    labelFlush: true,
+                    labelOverlap: true,
                     formatType: xScaleType,
                     format:
                       (isMobile ? xScaleMobileFormat : xScaleFormat) ||


### PR DESCRIPTION
## Description

- label flush on overlap

Fixes # (issue)

<img width="563" alt="Screenshot 2022-04-22 at 15 49 45" src="https://user-images.githubusercontent.com/7962097/164717765-dff7800d-6e72-4028-a387-f09f41641f90.png">

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
