### PR TITLE
Handle missing metadata in KeyMetric

### DIFF
--- a/src/components/HURUmap/KeyMetric/index.js
+++ b/src/components/HURUmap/KeyMetric/index.js
@@ -17,7 +17,7 @@ const KeyMetric = ({
   displayFormat,
   parentName,
   parentFormattedValue,
-  metadata: { source, url },
+  metadata: { source, url } = {},
   ...props
 }) => {
   const classes = useStyles(props);


### PR DESCRIPTION
## Description

Current code assumes metadata will always be present in `KeyMetric`. This PR handles cases where `metadata` is `undefined`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

