### PR TITLE
Limit story content image width

### DIFF
--- a/src/components/StoryPage/index.js
+++ b/src/components/StoryPage/index.js
@@ -37,6 +37,8 @@ function StoryPage({
                   alt="article"
                   src={image}
                   layout="fill"
+                  height={undefined}
+                  width={undefined}
                   objectFit="cover"
                 />
               </figure>

--- a/src/components/StoryPage/useStyles.js
+++ b/src/components/StoryPage/useStyles.js
@@ -25,6 +25,15 @@ const useStyles = makeStyles(({ typography, breakpoints }) => ({
   },
   content: {
     marginTop: typography.pxToRem(20),
+    "& .wp-block-image > img": {
+      height: "auto",
+      objectFit: "contain",
+      objectPosition: "top",
+      width: "100%",
+      [breakpoints.up("lg")]: {
+        width: typography.pxToRem(768),
+      },
+    },
   },
   relatedTitle: {
     textAlign: "center",


### PR DESCRIPTION
## Description

The current implementation allowed the content image to take as much width as it needed. The assumption was images would be pre-processed before being used on the site. This doesn't appear to be the case. This PR limits the maximum width based on screen size.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![s](https://user-images.githubusercontent.com/1779590/177963953-6d69be30-2558-4598-a417-3d3e4f2d4131.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

